### PR TITLE
feat: add new env vars for org profile and local testing

### DIFF
--- a/src/content/docs/contributing/development.mdx
+++ b/src/content/docs/contributing/development.mdx
@@ -40,6 +40,18 @@ application.
 
 Collect the configuration values as suggested.
 
+Additionally, to run alongside Chinmina, there are several Buildkite Agent
+containers that are started. These will require the following environment
+variables to be forwarded in order to run correctly:
+
+###### `BUILDKITE_AGENT_TOKEN`
+
+The agent token available from Buildkite when setting up a queue.
+
+###### `BUILDKITE_AGENT_TAGS`
+
+Used in testing only. These comma-separated, key-value pairs should be provided in order for the created agent containers to accept jobs.
+
 ## Server configuration
 
 <Steps>
@@ -66,6 +78,6 @@ Run:
 - `make test` to ... run the tests
 - `make docker` to start the system with Docker Compose, running Chinmina, the Buildkite agent and Jaeger.
 
-When `compose` is running, the Builkite agents will process jobs from pipelines
+When `compose` is running, the Buildkite agents will process jobs from pipelines
 in your test organization, and authenticate to GitHub. Jaeger is accessible to
 observe the Chinmina telemetry.

--- a/src/content/docs/reference/configuration.md
+++ b/src/content/docs/reference/configuration.md
@@ -91,10 +91,6 @@ Testing only. The issuer URL expected on incoming OIDC JWT tokens.
 The Buildkite token used to access the Buildkite REST API. Should only be
 supplied the `read_pipelines` scope.
 
-###### `BUILDKITE_AGENT_TAGS` 
-
-Used in testing only. These comma-separated, key-value pairs should be provided in order for the created agent containers to accept jobs.
-
 ## GitHub API
 
 :::tip
@@ -125,8 +121,8 @@ The ID for the installation of the App in your organization.
 
 ###### `GITHUB_ORG_PROFILE`
 
-The location of your organization profile, if in use. This should be a URL of
-the form `https://github.com/<OWNER>/<REPO>/<PATH_TO_FILE>`. No other format is accepted.
+The location of your organization profile, if in use. This should be a triplet
+of the form `<OWNER>:<REPO>:<PATH_TO_FILE>`. No other format is accepted.
 
 The contents of this organization profile must conform to the [organization profile configuration format][org-profile-config].
 

--- a/src/content/docs/reference/configuration.md
+++ b/src/content/docs/reference/configuration.md
@@ -91,6 +91,10 @@ Testing only. The issuer URL expected on incoming OIDC JWT tokens.
 The Buildkite token used to access the Buildkite REST API. Should only be
 supplied the `read_pipelines` scope.
 
+###### `BUILDKITE_AGENT_TAGS` 
+
+Used in testing only. These comma-separated, key-value pairs should be provided in order for the created agent containers to accept jobs.
+
 ## GitHub API
 
 :::tip
@@ -117,7 +121,14 @@ GitHub App ID of the app itself.
 
 ###### `GITHUB_APP_INSTALLATION_ID` :badge[required]
 
-The ID for the installation of the App in your organisation.
+The ID for the installation of the App in your organization.
+
+###### `GITHUB_ORG_PROFILE`
+
+The location of your organization profile, if in use. This should be a URL of
+the form `https://github.com/<OWNER>/<REPO>/<PATH_TO_FILE>`. No other format is accepted.
+
+The contents of this organization profile must conform to the [organization profile configuration format][org-profile-config].
 
 ## Open Telemetry
 
@@ -202,3 +213,4 @@ variables available.
 :::
 
 [otel-exporter-config]: https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options
+[org-profile-config]: ../organization-profile

--- a/src/content/docs/reference/organization-profile.md
+++ b/src/content/docs/reference/organization-profile.md
@@ -1,5 +1,5 @@
 ---
-title: Organization Profiles
+title: Organization profiles
 description: Details of what an organization profile is and how it is used.
 ---
 
@@ -7,11 +7,16 @@ Organization profiles are a way to facilitate cross-repository access for
 pipelines as well as managing the permissions provided by the tokens that
 Chinmina Bridge creates.
 
+If you are using Chinmina to manage Buildkite's access to GitHub, you will
+need to use organization profiles in order to provide access to non-public
+repositories. Examples where you may need to do this include accessing private
+packages or releases, or loading Buildkite plugins from private repositories.
+
 :::tip
 
-To use an organization profile, you must provide the URL of the profile in the
-`GITHUB_ORG_PROFILE` environment variable, as well as request the profile in
-your request to Chinmina. If a profile is not specified, or if there is no
+To use an organization profile, you must provide the location of the profile in
+the `GITHUB_ORG_PROFILE` environment variable, as well as request the profile 
+in your request to Chinmina. If a profile is not specified, or if there is no
 profile configured for the organization, Chinimina will instead default to
 providing access to the repository that the pipeline is running in.
 

--- a/src/content/docs/reference/organization-profile.md
+++ b/src/content/docs/reference/organization-profile.md
@@ -1,0 +1,78 @@
+---
+title: Organization Profiles
+description: Details of what an organization profile is and how it is used.
+---
+
+Organization profiles are a way to facilitate cross-repository access for 
+pipelines as well as managing the permissions provided by the tokens that
+Chinmina Bridge creates.
+
+:::tip
+
+To use an organization profile, you must provide the URL of the profile in the
+`GITHUB_ORG_PROFILE` environment variable, as well as request the profile in
+your request to Chinmina. If a profile is not specified, or if there is no
+profile configured for the organization, Chinimina will instead default to
+providing access to the repository that the pipeline is running in.
+
+:::
+
+# Organization Profile Structure
+
+The organization profile is provided as a YAML file with structure as follows:
+
+```yaml
+organization:
+    profiles:
+        - name: "<profile-name>"
+            repositories: 
+                - "<repository-name>"
+            permissions: ["<permission>"]
+```
+
+## Fields
+
+
+### `organization`
+
+The root element that contains all organization-related configurations.
+
+### `profiles`
+
+A list of profiles within the organization. Each profile must contain:
+
+#### `name`
+
+The name of the profile. This should be a unique identifier for the profile.
+
+#### `repositories`
+
+A list of repositories that the profile has access to. This list includes 
+only the repository name and does not include the owner or organization name.
+
+#### `permissions`
+
+A list of permissions granted to the profile. These permissions are defined
+in the [GitHub documentation for tokens][github-token-permissions].
+
+# Example
+
+```yaml
+organization:
+  profiles:
+    # allow read access to a set of buildkite-plugins
+    - name: "buildkite-plugin"
+      # array of repos accessible to the profile
+      repositories: 
+        - somewhat-private-buildkite-plugin
+        - very-private-buildkite-plugin
+      permissions: ["contents:read"]
+      
+    # allow package access to any repository
+    - name: "package-registry"
+    # '*' indicates all, when specified must be only value. No other wildcards supported.
+      repositories: ["*"]
+      permissions: ["packages:read"]
+```
+
+[github-token-permissions]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token


### PR DESCRIPTION
Add references to local testing variables and information regarding `GITHUB_ORG_PROFILE` configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new configuration option: `GITHUB_ORG_PROFILE`, specifying the organization profile location format.
  - Updated the description for `GITHUB_APP_INSTALLATION_ID` to correct spelling from "organisation" to "organization."
  - Introduced a new document detailing organization profiles, including their usage, required fields, and an example YAML configuration.
  - Enhanced documentation for Buildkite Agent containers with new environment variables required for setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->