### PR TITLE
feat: add D2 for diagrams

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,7 @@ on:
   # Trigger the workflow every time you push to the `main` branch
   # Using a different branch name? Replace `main` with your branch’s name
   push:
-    branches: [ main ]
+    branches: [main]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
@@ -20,12 +20,15 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
+      - name: Install D2 diagramming tool
+        run: |
+          curl -fsSL https://d2lang.com/install.sh | sh -s --
       - name: Install, build, and upload your site
         uses: withastro/action@v3
         # with:
-          # path: . # The root location of your Astro project inside the repository. (optional)
-          # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
-          # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+        # path: . # The root location of your Astro project inside the repository. (optional)
+        # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
+        # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
   deploy:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # build output
 dist/
+public/d2/
+
 # generated types
 .astro/
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository is the source for the [Chinmina Bridge](https://github.com/chinm
 
 This documentation uses the [Starlight](https://starlight.astro.build/) project (based on [Astro](https://astro.build/)).
 
+Inline diagrams can be included using [the D2 diagramming language](https://d2lang.com). There is a VS Code extension as well as an online playground to help author the diagrams.
+
 Contributions are welcome! Fork the repo and create a PR for review.
 
 ## Local development
@@ -12,6 +14,7 @@ Contributions are welcome! Fork the repo and create a PR for review.
 
 1. Node: `mise install`
 2. PNPM: `corepack enable && corepack install`
+3. [D2](https://d2lang.com/tour/install): `curl -fsSL https://d2lang.com/install.sh | sh -s --` (Check out [the install instructions](https://d2lang.com/tour/install) for more options.)
 
 ### Run the dev server
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,8 @@ import { defineConfig } from "astro/config"
 import starlight from "@astrojs/starlight"
 import starlightHeadingBadges from "starlight-heading-badges"
 
+import d2 from "astro-d2"
+
 // https://astro.build/config
 export default defineConfig({
   site: "https://chinmina.github.io",
@@ -40,6 +42,9 @@ export default defineConfig({
           autogenerate: { directory: "contributing" },
         },
       ],
+    }),
+    d2({
+      layout: "elk",
     }),
   ],
 })

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@astrojs/check": "^0.9.4",
     "@astrojs/starlight": "^0.32.4",
     "astro": "^5.5.4",
+    "astro-d2": "^0.7.0",
     "sharp": "^0.33.5",
     "starlight-heading-badges": "^0.5.0",
     "typescript": "^5.8.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       astro:
         specifier: ^5.5.4
         version: 5.5.4(rollup@4.37.0)(typescript@5.8.2)(yaml@2.6.0)
+      astro-d2:
+        specifier: ^0.7.0
+        version: 0.7.0(astro@5.5.4(rollup@4.37.0)(typescript@5.8.2)(yaml@2.6.0))
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
@@ -720,6 +723,12 @@ packages:
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
+
+  astro-d2@0.7.0:
+    resolution: {integrity: sha512-g+lD6xZQcCT2T35zqC9cJKWJJZGhjQUmCWEHrUTXfaQYnpt7ubHjoYHAdYPweftigFrq2S5T2jdTT/BkManqTg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      astro: '>=5.0.0'
 
   astro-expressive-code@0.40.2:
     resolution: {integrity: sha512-yJMQId0yXSAbW9I6yqvJ3FcjKzJ8zRL7elbJbllkv1ZJPlsI0NI83Pxn1YL1IapEM347EvOOkSW2GL+2+NO61w==}
@@ -2800,6 +2809,13 @@ snapshots:
   array-iterate@2.0.1: {}
 
   astring@1.9.0: {}
+
+  astro-d2@0.7.0(astro@5.5.4(rollup@4.37.0)(typescript@5.8.2)(yaml@2.6.0)):
+    dependencies:
+      astro: 5.5.4(rollup@4.37.0)(typescript@5.8.2)(yaml@2.6.0)
+      hast-util-from-html: 2.0.3
+      hast-util-to-html: 9.0.5
+      unist-util-visit: 5.0.0
 
   astro-expressive-code@0.40.2(astro@5.5.4(rollup@4.37.0)(typescript@5.8.2)(yaml@2.6.0)):
     dependencies:

--- a/src/content/docs/guides/buildkite-integration.mdx
+++ b/src/content/docs/guides/buildkite-integration.mdx
@@ -50,7 +50,7 @@ credential helper is configured in Git.
 
 In essence, Git calls the Credential Helper, which defers to Chinmina
 (authenticated with an OIDC token for this pipeline). Chinmina returns a result
-in the Git credentials helper format containing the required username and the
+in the Git credentials helper format containing the required username, and the
 token created for the pipeline.
 
 ```d2 sketch=true title="sequence diagram showing Git authentication integration with Chinmina"

--- a/src/content/docs/guides/buildkite-integration.mdx
+++ b/src/content/docs/guides/buildkite-integration.mdx
@@ -43,6 +43,41 @@ Enabling at the agent level is recommended (see below).
 
 :::
 
+## How it works
+
+The following gives a high-level overview of the actions performed when the
+credential helper is configured in Git.
+
+In essence, Git calls the Credential Helper, which defers to Chinmina
+(authenticated with an OIDC token for this pipeline). Chinmina returns a result
+in the Git credentials helper format containing the required username and the
+token created for the pipeline.
+
+```d2 sketch=true title="sequence diagram showing Git authentication integration with Chinmina"
+shape: sequence_diagram
+
+buildkite-job: Buildkite Job
+git: Git
+credential-helper: Credential Helper
+chinmina: Chinmina Bridge
+buildkite-api: Buildkite API
+
+buildkite-job.clone -> git.auth: clone
+git.auth -> credential-helper.req: get credentials
+
+credential-helper.req -> buildkite-api.token: request OIDC token
+credential-helper.req <- buildkite-api.token: Buildkite OIDC token
+
+credential-helper.req -> chinmina.helper: request GH token\n(using Buildkite OIDC token)
+chinmina.helper -> buildkite-api.repo: get pipeline details
+chinmina.helper <- buildkite-api.repo: pipeline repository
+credential-helper.req <- chinmina.helper: scoped GitHub token
+
+git.auth <- credential-helper.req: \"x-access-token\" /app-token
+
+buildkite-job.clone <- git.auth: complete
+```
+
 ## Configuration
 
 ### On pipeline steps


### PR DESCRIPTION
D2 uses a binary to generate diagrams, but doesn't require a browser like most Mermaid options. The output is pretty decent too, and the language is quite straightforward.

Using D2 allowed the reinstatement of a sequence diagram that was previously published in the Chinmina repository directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced diagramming support with the integration of the D2 tool into the CI build and site configuration.
  - Added a new dependency to enable advanced diagram functionalities.

- **Documentation**
  - Updated the documentation and README with instructions for using D2 to create inline diagrams.
  - Introduced a detailed guide section with a sequence diagram outlining the authentication process in the Buildkite integration.

- **Chores**
  - Improved CI configuration formatting and updated ignore settings to exclude D2-related files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->