### PR TITLE
docs: how it works section includes mention of organization profiles

### DIFF
--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -71,6 +71,12 @@ Chinmina Bridge accepts HTTP connections from Buildkite agents. The request
 includes a [Buildkite OIDC][buildkite-oidc] token that is used to authorize
 requests.
 
+For `git-credentials` requests, a set of credential helpers are configured on the Buildkite agent's environment on startup.
+Once a git operation is specified, git will iterate over all of the configured credential helpers by making requests to Chinmina until
+one of the returned credentials are valid. These credentials are used for subsequent git operations.
+
+![Chinmina git-credentials auth flow](../../assets/chinmina-git-credentials-auth-flow.png)
+
 ### No organization profile (default)
 
 > [!TIP]

--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -71,12 +71,6 @@ Chinmina Bridge accepts HTTP connections from Buildkite agents. The request
 includes a [Buildkite OIDC][buildkite-oidc] token that is used to authorize
 requests.
 
-For `git-credentials` requests, a set of credential helpers are configured on the Buildkite agent's environment on startup.
-Once a git operation is specified, git will iterate over all of the configured credential helpers by making requests to Chinmina until
-one of the returned credentials are valid. These credentials are used for subsequent git operations.
-
-![Chinmina git-credentials auth flow](../../assets/chinmina-git-credentials-auth-flow.png)
-
 ### No organization profile (default)
 
 > [!TIP]

--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -71,19 +71,37 @@ Chinmina Bridge accepts HTTP connections from Buildkite agents. The request
 includes a [Buildkite OIDC][buildkite-oidc] token that is used to authorize
 requests.
 
-The token identifies the Buildkite pipeline that is executing, so the associated
-repository can be looked up.
+### No organization profile (default)
 
-If the request is valid, GitHub is used to create an app token with
-`contents:read` permissions on the pipeline's repository. This token has a
-maxiumum lifetime of an hour (due to caching it may only last for 45 minutes
-however).
+> [!TIP]
+> This is Chinmina's default behaviour. Unless you've explicitly configured [organization profiles](reference/organization-profile),
+> you should expect Chinmina to behave as described below.
 
-Three endpoints are exposed:
+If no organization profile is specified, the Buildkite OIDC token identifies the Buildkite
+pipeline that is executing, so the associated repository can be looked up. If the associated and requested repositories match,
+the request is valid.
 
-- `/token`, which returns a token and its expiry, and
+For valid requests, GitHub is used to create an app token with `contents:read` permissions for the pipeline's repository.
+
+### Organization profile
+
+If an organization profile is specified, Chinmina verifies that the requested repository is allow-listed in the specified profile's config.
+
+For valid requests, GitHub is used to create an app token with permissions specified by the profile's config for the requested repository.
+
+> [!NOTE]
+> In both scenarios, tokens vended by Chinmina have a maxiumum lifetime of an hour (due to caching it may only last for 45 minutes however).
+
+## Endpoints
+
+Five endpoints are exposed:
+
+- `/token`, which returns a token and its expiry
+- `/organization/token/{profile}`, which returns a token and its expiry for a given organization profile
 - `/git-credentials`, which returns the token and repository metadata in the
   [Git Credentials format][git-credential-helper].
+- `/organization/git-credentials/{profile}`, which returns the token and repository metadata in the
+  [Git Credentials format][git-credential-helper] for a given organization profile.
 - `/healthcheck`, which returns 200. It is used for healthcheck requests from
   load balancers and the like.
 

--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -90,7 +90,7 @@ If an organization profile is specified, Chinmina verifies that the requested re
 For valid requests, GitHub is used to create an app token with permissions specified by the profile's config for the requested repository.
 
 > [!NOTE]
-> In both scenarios, tokens vended by Chinmina have a maxiumum lifetime of an hour (due to caching it may only last for 45 minutes however).
+> In both scenarios, tokens vended by Chinmina have a maximum lifetime of an hour (due to caching, it may only last for 45 minutes, however).
 
 ## Endpoints
 

--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -77,9 +77,8 @@ requests.
 > This is Chinmina's default behaviour. Unless you've explicitly configured [organization profiles](reference/organization-profile),
 > you should expect Chinmina to behave as described below.
 
-If no organization profile is specified, the Buildkite OIDC token identifies the Buildkite
-pipeline that is executing, so the associated repository can be looked up. If the associated and requested repositories match,
-the request is valid.
+If no organization profile is specified, the Buildkite OIDC token identifies the Buildkite pipeline that is executing,
+so the associated repository can be looked up. If the associated and requested repositories match, the request is valid.
 
 For valid requests, GitHub is used to create an app token with `contents:read` permissions for the pipeline's repository.
 


### PR DESCRIPTION
## Purpose
- Updates the docs to explain how Chinmina operates at a high-level, for both the default scenario and when an organization profile is specified
- Updates the list of endpoints to reflect support for organization profiles

## Context
- Identified as an improvement after pairing with others on supporting organization profiles 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Restructured authorization documentation to clearly separate default and organization profile scenarios.
  - Expanded API endpoints section to include organization-profile-specific token and git-credentials endpoints.
  - Clarified token lifetime details and authorization logic for all cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->