### PR TITLE
docs: API endpoint reference documentation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -41,7 +41,21 @@ export default defineConfig({
         },
         {
           label: "Reference",
-          autogenerate: { directory: "reference" },
+          items: [
+            "reference/configuration",
+            "reference/git-credentials-format",
+            "reference/organization-profile",
+            {
+              label: "API",
+              items: [
+                "reference/api/health-check-and-status",
+                "reference/api/git-credentials",
+                "reference/api/post-token",
+                "reference/api/profile-git-credentials",
+                "reference/api/profile-token",
+              ],
+            },
+          ],
         },
         {
           label: "Contributing",

--- a/src/content/docs/reference/api/git-credentials.md
+++ b/src/content/docs/reference/api/git-credentials.md
@@ -1,0 +1,69 @@
+---
+title: POST /git-credentials
+description: Git credential helper endpoint that returns GitHub tokens in Git credential format.
+---
+
+The `POST /git-credentials` endpoint returns GitHub installation tokens in Git's [credential helper format][helper-protocol], enabling seamless integration with Git operations like clone, fetch, and pull.
+
+## Purpose
+
+This endpoint serves the same underlying function as `/token` (vending GitHub installation tokens), however its request and response format follows Git's [credential helper protocol][helper-protocol]. This allows Chinmina Bridge to act as a Git credential helper, enabling transparent authentication for Git operations without requiring separate credential extraction and configuration steps.
+
+See the [Buildkite integration guide](../../guides/buildkite-integration) for details on how this endpoint is used in practice.
+
+:::note
+
+The `/token` endpoint returns the same data in a generic JSON format. Use `/git-credentials` when integrating directly with Git's credential helper system. Use `/token` when you need token metadata, are making direct API calls, or want more flexible response handling.
+
+:::
+
+## Request format
+
+### Headers
+
+| Header          | Required    | Description                                |
+| --------------- | ----------- | ------------------------------------------ |
+| `Authorization` | Yes         | Bearer token containing Buildkite OIDC JWT |
+| `Content-Type`  | Recommended | Should be `text/plain`                     |
+
+### Request body
+
+The request body follows Git's credential helper input format:
+
+```text
+protocol=https
+host=github.com
+path=owner/repository
+```
+
+## Response format
+
+### Success response (200 OK)
+
+When a token is successfully vended, the response contains Git credential helper output:
+
+```text
+username=x-access-token
+password=ghs_...
+password_expiry_utc=1705320600
+```
+
+The response body is plain text with newline-separated key-value pairs. Git parses this and uses the credentials for the requested operation.
+
+### Empty response (200 OK)
+
+When the requested repository does not match the pipeline's repository the endpoint returns a successful but empty response. See [Git credentials format](../../reference/git-credentials-format#empty-response) for details on empty response behavior.
+
+### Error responses
+
+| Status code               | Condition                               | Response body |
+| ------------------------- | --------------------------------------- | ------------- |
+| 401 Unauthorized          | Missing or invalid JWT                  | Plain text    |
+| 403 Forbidden             | JWT valid but claims insufficient       | Plain text    |
+| 500 Internal Server Error | Token vending failure, GitHub API error | Plain text    |
+
+Error responses are returned in plain text. Any response that Git does not
+recognize as valid for the format is regarded as an error and discarded. Note
+that the server will never return client content as part of an error message.
+
+[helper-protocol]: ../git-credentials-format

--- a/src/content/docs/reference/api/health-check-and-status.md
+++ b/src/content/docs/reference/api/health-check-and-status.md
@@ -1,0 +1,41 @@
+---
+title: GET /healthcheck
+description: Health check endpoint for monitoring Chinmina Bridge service availability.
+---
+
+The `GET /healthcheck` endpoint provides a simple mechanism to verify that the Chinmina Bridge service is running and accepting HTTP requests.
+
+For documentation of token-issuing endpoints, see [POST /token](./post-token), [POST /git-credentials](./git-credentials), and [Profile-Scoped Endpoints](./profile-scoped-endpoints).
+
+## Purpose
+
+This endpoint is designed for use with Kubernetes liveness probes, load balancer health checks, and monitoring systems. It provides a lightweight, unauthenticated health check that validates only HTTP server functionality, not external dependencies.
+
+:::note
+
+The health check does not validate the state of GitHub API, Buildkite API, or AWS KMS connectivity. Use the token-issuing endpoints if you need to verify full system health.
+
+:::
+
+## Request format
+
+This endpoint is not authenticated and takes no parameters.
+
+## Response format
+
+The endpoint returns an HTTP status code with no response body:
+
+| Status Code           | Meaning                                                  |
+| --------------------- | -------------------------------------------------------- |
+| `200 OK`              | Service is running and accepting requests                |
+| `503 Service Unavail` | Service is not ready (typically during startup/shutdown) |
+
+### Example request
+
+```bash
+curl http://localhost:8080/healthcheck
+```
+
+## Error responses
+
+This endpoint does not return JSON error responses. HTTP status codes are the sole indicator of health.

--- a/src/content/docs/reference/api/post-token.md
+++ b/src/content/docs/reference/api/post-token.md
@@ -1,0 +1,74 @@
+---
+title: POST /token
+description: API reference for the token vending endpoint that returns short-lived GitHub installation tokens.
+---
+
+The `POST /token` endpoint vends short-lived GitHub installation tokens validated against Buildkite OIDC tokens. The endpoint operates in two modes: default mode (automatic pipeline repository detection) and profile mode (custom permission scopes and multi-repository access).
+
+## Purpose
+
+This endpoint returns GitHub installation tokens in JSON format. Use `/token`
+when you need token metadata, are making direct API calls, or want more flexible
+response handling.
+
+For Git credential helper integration, use the [`POST
+/git-credentials`](git-credentials.md) endpoint instead, which returns tokens in
+Git's credential helper format.
+
+:::note
+
+Both `/token` and `/git-credentials` vend the same underlying GitHub
+installation tokens. Choose the endpoint based on your integration method:
+`/token` for JSON responses, `/git-credentials` for Git credential helper
+protocol.
+
+:::
+
+## Request format
+
+### Headers
+
+| Header          | Required | Description                                |
+| --------------- | -------- | ------------------------------------------ |
+| `Authorization` | Yes      | Bearer token containing Buildkite OIDC JWT |
+| `Content-Type`  | Yes      | Must be `application/json`                 |
+
+### Request body
+
+The request body is expected to be empty.
+
+## Response format
+
+### Success response (200 OK)
+
+When a token is successfully vended, the response is a JSON object:
+
+```json
+{
+  "organizationSlug": "my-org",
+  "profile": "org:default",
+  "repositoryUrl": "https://github.com/owner/repository",
+  "repositories": ["owner/repository"],
+  "permissions": ["contents:read"],
+  "token": "ghs_...",
+  "expiry": "2025-12-21T10:00:00Z"
+}
+```
+
+| Field              | Type   | Description                                                             |
+| ------------------ | ------ | ----------------------------------------------------------------------- |
+| `organizationSlug` | string | Buildkite organization from JWT claims                                  |
+| `profile`          | string | Profile identifier that was used                                        |
+| `repositoryUrl`    | string | The requested repository URL: this will always be empty                 |
+| `repositories`     | array  | List of repository names the token has access to (format: `owner/repo`) |
+| `permissions`      | array  | Permissions granted (e.g., `["contents:read", "packages:write"]`)       |
+| `token`            | string | GitHub installation token (format: `ghs_...`)                           |
+| `expiry`           | string | ISO 8601 timestamp when token expires                                   |
+
+### Error responses
+
+| Status code                    | Condition                                                     |
+| ------------------------------ | ------------------------------------------------------------- |
+| `401 Unauthorized`             | Missing or invalid JWT                                        |
+| `413 Request Entity Too Large` | Request body exceeds 20 KB                                    |
+| `500 Internal Server Error`    | Token vending failure, profile not found, or GitHub API error |

--- a/src/content/docs/reference/api/profile-git-credentials.md
+++ b/src/content/docs/reference/api/profile-git-credentials.md
@@ -1,0 +1,100 @@
+---
+title: POST /organization/git-credentials/{profile}
+description: Profile-scoped Git credential helper endpoint that returns GitHub tokens for a specific organization profile.
+---
+
+The `POST /organization/git-credentials/{profile}` endpoint returns GitHub
+installation tokens in Git's [credential helper format][helper-protocol], using
+token permissions granted by a specified organization profile.
+
+## Purpose
+
+This endpoint provides explicit control over which organization profile is used
+when vending GitHub tokens. Profiles allow configuring different sets of
+repositories and permissions for different use cases.
+
+This endpoint serves the same underlying function as [POST
+/organization/token/{profile}](./profile-token) (vending GitHub installation
+tokens), however its request and response format follows Git's [credential
+helper protocol][helper-protocol]. This allows Chinmina Bridge to act as a Git
+credential helper, enabling transparent authentication for Git operations
+without requiring separate credential extraction and configuration steps.
+
+:::note
+
+Use `/organization/git-credentials/{profile}` when integrating directly with
+Git's credential helper system. Use `/organization/token/{profile}` when you
+need token metadata, are making direct API calls, or want more flexible response
+handling.
+
+:::
+
+### See also
+
+- [Buildkite integration guide](../../guides/buildkite-integration) for details
+  on how this endpoint is used in practice.
+- [Profile system](../../guides/profile-access-control#profile-system) for
+  details on how profiles are configured and managed.
+
+## Request format
+
+### Headers
+
+| Header          | Required    | Description                                |
+| --------------- | ----------- | ------------------------------------------ |
+| `Authorization` | Yes         | Bearer token containing Buildkite OIDC JWT |
+| `Content-Type`  | Recommended | Should be `text/plain`                     |
+
+## Parameters
+
+### Profile parameter
+
+The `{profile}` path parameter specifies which organization profile to use, in the format:
+
+```
+org:{profile-name}
+```
+
+Example: `POST /organization/git-credentials/org:deploy`
+
+### Request body
+
+The request body follows Git's credential helper input format:
+
+```text
+protocol=https
+host=github.com
+path=owner/repository
+```
+
+## Response format
+
+### Success response (200 OK)
+
+When a token is successfully vended:
+
+```text
+username=x-access-token
+password=ghs_...
+password_expiry_utc=1705320600
+```
+
+The response body is plain text with newline-separated key-value pairs. Git parses this and uses the credentials for the requested operation.
+
+### Empty response (200 OK)
+
+When the requested repository is not in the profile's allowed repository list, the endpoint returns a successful but empty response. See [Git credentials format](../git-credentials-format#empty-response) for details. This allows Git credential helpers to fall through to other credential sources.
+
+### Error responses
+
+| Status code               | Condition                               | Response body      |
+| ------------------------- | --------------------------------------- | ------------------ |
+| 400 Bad Request           | Invalid profile format or parameter     | JSON error message |
+| 401 Unauthorized          | Missing or invalid JWT                  | JSON error message |
+| 403 Forbidden             | JWT valid but claims insufficient       | JSON error message |
+| 404 Not Found             | Profile does not exist                  | JSON error message |
+| 500 Internal Server Error | Token vending failure, GitHub API error | JSON error message |
+
+Error responses are returned in JSON format. Any response that Git does not recognize as valid for the format is regarded as an error and discarded.
+
+[helper-protocol]: ../git-credentials-format

--- a/src/content/docs/reference/api/profile-token.md
+++ b/src/content/docs/reference/api/profile-token.md
@@ -1,0 +1,79 @@
+---
+title: POST /organization/token/{profile}
+description: Profile-scoped token endpoint that returns GitHub tokens with profile-specific permissions.
+---
+
+The `POST /organization/token/{profile}` endpoint returns GitHub
+installation tokens in JSON format, using token permissions granted by a
+specified organization profile.
+
+:::note
+
+Use `/organization/git-credentials/{profile}` when integrating directly with
+Git's credential helper system. Use `/organization/token/{profile}` when you need token metadata, are
+making direct API calls, or want more flexible response handling.
+
+:::
+
+### See also
+
+- [Buildkite integration guide](../../guides/buildkite-integration) for details
+  on how this endpoint is used in practice.
+- [Profile system](../../guides/profile-access-control#profile-system) for
+  details on how profiles are configured and managed.
+
+## Purpose
+
+This endpoint provides explicit control over which organization profile is used
+when vending GitHub tokens. Profiles allow configuring different sets of
+repositories and permissions for different use cases.
+
+## Request format
+
+### Headers
+
+| Header          | Required | Description                 |
+| --------------- | -------- | --------------------------- |
+| `Authorization` | Yes      | Bearer token containing JWT |
+| `Content-Type`  | Yes      | `application/json`          |
+
+## Parameters
+
+### Profile parameter
+
+The `{profile}` path parameter specifies which organization profile to use, in the format:
+
+```
+org:{profile-name}
+```
+
+Example: `POST /organization/token/org:deploy`
+
+### Request body
+
+The request body is expected to be empty.
+
+## Response format
+
+### Success response (200 OK)
+
+```json
+{
+  "token": "ghs_...",
+  "expiresAt": "2025-01-15T10:30:00Z"
+}
+```
+
+### Empty response (200 OK)
+
+When the requested repository is not in the profile's repository list, the endpoint returns a successful empty response. This allows credential helpers to fall through to other authentication methods.
+
+## Error responses
+
+| Status code      | Condition                     | Response   |
+| ---------------- | ----------------------------- | ---------- |
+| 400 Bad Request  | Invalid profile format        | JSON error |
+| 401 Unauthorized | Missing or invalid JWT        | JSON error |
+| 403 Forbidden    | Insufficient JWT claims       | JSON error |
+| 404 Not Found    | Profile does not exist        | JSON error |
+| 500 Server Error | Token vending or GitHub error | JSON error |

--- a/src/content/docs/reference/git-credentials-format.md
+++ b/src/content/docs/reference/git-credentials-format.md
@@ -1,0 +1,66 @@
+---
+title: Git credentials format
+description: Reference documentation for Git's credential helper protocol format.
+---
+
+Credential helpers are a core part of Git's credential management system, implementing an extensible credential system for Git.
+
+For details on the Credential Helper system, see Git's [Custom helpers][git-custom-helpers] documentation, detailing how helpers are written and invoked.
+
+## Git credential helper protocol
+
+Git's credential helper protocol uses a simple text-based format for both input and output. Credential helpers receive requests on stdin and return credentials on stdout. This is [specified fully in Git's documentation][git-iofmt], but the following will serve as a primer.
+
+### Input format
+
+Git sends credential requests in this format:
+
+```text
+protocol=https
+host=github.com
+path=owner/repository
+```
+
+Each line contains a key-value pair separated by `=`. The protocol and host fields are always present, while the path may be included depending on the Git operation and URL format.
+
+### Output format
+
+Credential helpers respond with:
+
+```text
+username=x-access-token
+password=ghs_...
+```
+
+For GitHub token authentication, the username is conventionally set to `x-access-token` (though GitHub accepts any value), and the password contains the actual installation token.
+
+#### Optional fields
+
+The output format supports optional fields:
+
+##### `password_expiry_utc`
+
+Unix timestamp indicating when the password expires:
+
+```text
+username=x-access-token
+password=ghs_...
+password_expiry_utc=1705320600
+```
+
+This field is provided by Chinmina Bridge when vending tokens so that Git can use this information to proactively refresh credentials before they expire.
+
+### Empty response
+
+An empty response (no key-value pairs) signals to Git that the credential helper cannot provide credentials for the requested URL. This causes Git to try other configured helpers or prompt the user (if there are no more helpers to try).
+
+Empty responses are used when:
+
+- The requested repository does not match a repository that can be supported by this helper
+- The credential helper does not handle the specific host or protocol
+- No valid credentials are available for the request
+
+This behaviour allows multiple credential helpers to coexist, with each handling different URL patterns.
+
+[git-custom-helpers]: https://git-scm.com/docs/gitcredentials#_custom_helpers
+[git-iofmt]: https://git-scm.com/docs/git-credential#IOFMT


### PR DESCRIPTION
## Purpose

Enable users to understand and integrate with Chinmina Bridge's HTTP API by providing reference documentation for all exposed endpoints. This documentation supports both direct API consumers and those building integrations beyond the standard Buildkite plugin.

## Context

The branch includes documentation for five API endpoints:
- `POST /token` and `POST /git-credentials` for pipeline-scoped token vending
- `POST /profile/{org}/{profile}/token` and `POST /profile/{org}/{profile}/git-credentials` for profile-based access
- Health check and status endpoints for operational monitoring

Supporting reference material covers Git credential format semantics and expanded organization profile documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive API endpoint documentation covering health checks, token generation, and Git credential integration.
  * Added Git credential helper protocol format reference guide.

* **Chores**
  * Updated Reference sidebar structure to use explicit enumeration instead of auto-discovery, improving navigation clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->