### PR TITLE
docs: claim-based access control for organization profiles

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -35,6 +35,7 @@ export default defineConfig({
             "guides/buildkite-integration",
             "guides/kms",
             "guides/observability",
+            "guides/profile-access-control",
             "guides/verifying-releases",
           ],
         },

--- a/src/content/docs/guides/profile-access-control.mdx
+++ b/src/content/docs/guides/profile-access-control.mdx
@@ -1,0 +1,176 @@
+---
+title: Restricting profile access
+description: Control which pipelines can use organization profiles with claim-based matching.
+---
+
+import { Aside } from "@astrojs/starlight/components"
+
+Organization profiles can restrict access to specific Buildkite pipelines using claim-based matching. Match rules evaluate JWT claims from the Buildkite OIDC token against configured patterns, providing fine-grained access control.
+
+See the [organization profile reference](../reference/organization-profile) for complete configuration details.
+
+## Use cases
+
+### Release pipeline access
+
+Pipelines ending in `-release` on the `main` branch can publish packages.
+
+```yaml
+organization:
+  profiles:
+    - name: "release-publisher"
+      match:
+        - claim: pipeline_slug
+          valuePattern: ".*-release"
+        - claim: build_branch
+          value: "main"
+      repositories: [release-tools, shared-infra]
+      permissions: [contents:write, packages:write]
+```
+
+Add new release pipelines without updating profile configuration.
+
+### Production deployment
+
+Only specific production pipelines on the `main` branch can deploy infrastructure.
+
+```yaml
+organization:
+  profiles:
+    - name: "prod-deploy"
+      match:
+        - claim: pipeline_slug
+          valuePattern: "(silk|cotton)-prod"
+        - claim: build_branch
+          value: "main"
+      repositories: [infra]
+      permissions: [contents:write, deployments:write]
+```
+
+Enforce both pipeline and branch requirements in a single policy.
+
+### Baseline shared access
+
+All pipelines have read access to shared utilities.
+
+```yaml
+organization:
+  profiles:
+    - name: "shared-utilities"
+      # No `match` = available to all
+      repositories: [shared-utilities]
+      permissions: [contents:read]
+```
+
+Profiles without match rules work as before, available to any pipeline.
+
+## Match rule patterns
+
+### Exact matching
+
+Use `value` for known strings. This is the fastest match type.
+
+```yaml
+match:
+  - claim: pipeline_slug
+    value: "silk-prod"  # Matches only "silk-prod"
+```
+
+### Regex matching
+
+Use `valuePattern` for flexible patterns. Supports [RE2 regex syntax](https://github.com/google/re2/wiki/Syntax).
+
+```yaml
+match:
+  - claim: pipeline_slug
+    valuePattern: ".*-release"  # Matches any pipeline ending in "-release"
+```
+
+Patterns are automatically anchored to match the full string. Pattern `prod` matches only "prod", not "not-prod".
+
+### Multiple conditions
+
+All conditions must match (AND logic).
+
+```yaml
+match:
+  - claim: pipeline_slug
+    valuePattern: "silk-.*"
+  - claim: build_branch
+    value: "main"
+# Both conditions required
+```
+
+### No conditions
+
+Empty `match` array makes the profile available to all pipelines.
+
+```yaml
+match: []  # Available to any pipeline
+```
+
+## Available claims
+
+Match rules can evaluate the following JWT claims:
+
+| Claim | Description |
+|-------|-------------|
+| `pipeline_slug` | Pipeline's slug |
+| `pipeline_id` | Pipeline UUID |
+| `build_number` | Build number (as string) |
+| `build_branch` | Git branch name |
+| `build_tag` | Git tag (if present) |
+| `build_commit` | Git commit SHA |
+| `cluster_id`, `cluster_name` | Cluster identifiers |
+| `queue_id`, `queue_key` | Queue identifiers |
+| `agent_tag:NAME` | Dynamic agent tags |
+
+<Aside type="tip">
+Use `pipeline_slug` or `pipeline_id` as primary authorization factors. These claims are controlled by the Buildkite organization and provide the strongest authorization signal.
+</Aside>
+
+## Request flow
+
+```d2 sketch=true title="sequence diagram showing organization profile token request with claim matching"
+shape: sequence_diagram
+
+pipeline: Buildkite Pipeline
+chinmina: Chinmina Bridge
+buildkite-api: Buildkite API
+github: GitHub App
+
+pipeline.req -> chinmina.auth: "POST /organization/token/{profile}\n(with Buildkite OIDC token)"
+
+chinmina.auth -> chinmina.match: validate JWT claims
+chinmina.match -> chinmina.match: evaluate match rules\nagainst JWT claims
+
+chinmina.match -> buildkite-api.lookup: get pipeline details
+chinmina.match <- buildkite-api.lookup: pipeline metadata
+
+chinmina.match -> github.token: request scoped token\n(repos + permissions from profile)
+chinmina.match <- github.token: GitHub access token
+
+pipeline.req <- chinmina.auth: token + expiry
+```
+
+When match conditions are not met, Chinmina returns 403 immediately after match evaluation, before any external API calls.
+
+## Troubleshooting
+
+### Profile returns 403 (access denied)
+
+Pipeline doesn't match profile conditions.
+
+The HTTP response returns a generic "Forbidden" message. Check [audit logs](observability#audit-logs) for `attemptedPatterns` to see which condition failed and the `error` field for detailed information. Verify the pipeline's claim values match the configured patterns.
+
+### Profile returns 404 (unavailable: validation failed)
+
+Profile failed validation at service startup.
+
+Check service startup logs for validation warnings. Fix the invalid configuration (e.g., invalid regex pattern) and restart the service.
+
+### Profile matches too broadly
+
+Pattern is overly permissive.
+
+Review audit logs to identify unexpected matches. Make the pattern more specific. Patterns are automatically anchored, but `.*` can still match broadly.

--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -97,7 +97,8 @@ the pipeline, the associated GitHub repository is looked up, and a token with
 
 If the `/organization/*` routes are used, Chinmina will use the [organization
 profile][org-profile] to determine the repositories and permissions for the
-GitHub token (after authorizing the request).
+GitHub token. Profiles can optionally [restrict access](guides/profile-access-control)
+to specific pipelines via claim matching.
 
 ## Endpoints
 

--- a/src/content/docs/reference/organization-profile.md
+++ b/src/content/docs/reference/organization-profile.md
@@ -4,7 +4,8 @@ description: Details of what an organization profile is and how it is used.
 ---
 
 An organization profile defines sets of repository access and permissions available to
-**all** agents associated with the Buildkite organization.
+agents associated with the Buildkite organization, optionally restricted to specific
+pipelines via match rules.
 
 The location of the organizational profile is configured via the
 [`GITHUB_ORG_PROFILE`](../reference/configuration#github_org_profile)
@@ -28,9 +29,13 @@ The organization profile is provided as a YAML file with structure as follows:
 organization:
   profiles:
     - name: "<profile-name>"
-        repositories:
-          - "<repository-name>"
-        permissions: ["<permission>"]
+      match: # Optional: restricts which pipelines can use this profile
+        - claim: "<claim-name>"
+          value: "<exact-value>" # OR
+          valuePattern: "<regex>" # One of value/valuePattern required
+      repositories:
+        - "<repository-name>"
+      permissions: ["<permission>"]
 ```
 
 ### Fields
@@ -47,6 +52,19 @@ A list of profiles within the organization. Each profile must contain:
 
 The name of the profile. This should be a unique identifier for the profile.
 
+###### `match`
+
+_(optional)_
+
+A list of conditions that must all be satisfied (AND logic) for a pipeline to use this
+profile. If omitted or empty, the profile is available to all pipelines.
+
+Each match rule must specify:
+
+- `claim`: The JWT claim name to match against (see allowed claims below)
+- `value`: Exact string match, OR
+- `valuePattern`: RE2 regex pattern (automatically anchored for full-string matching)
+
 ###### `repositories`
 
 A list of repositories that the profile has access to. This list includes
@@ -56,6 +74,29 @@ only the repository name and does not include the owner or organization name.
 
 A list of permissions granted to the profile. See the [GitHub documentation for
 tokens][github-token-permissions] for available permission values.
+
+### Allowed claims for matching
+
+The following JWT claims can be used in match rules:
+
+| Claim                        | Description                                  |
+| ---------------------------- | -------------------------------------------- |
+| `pipeline_slug`              | Pipeline's slug                              |
+| `pipeline_id`                | Pipeline UUID                                |
+| `build_number`               | Build number (as string)                     |
+| `build_branch`               | Git branch name                              |
+| `build_tag`                  | Git tag (if present)                         |
+| `build_commit`               | Git commit SHA                               |
+| `cluster_id`, `cluster_name` | Cluster identifiers                          |
+| `queue_id`, `queue_key`      | Queue identifiers                            |
+| `agent_tag:NAME`             | Dynamic agent tags (e.g., `agent_tag:queue`) |
+
+:::tip
+
+See the [profile access control guide](../guides/profile-access-control) for use cases,
+pattern examples, and troubleshooting.
+
+:::
 
 ### Example
 
@@ -75,6 +116,16 @@ organization:
       # '*' indicates all, when specified must be only value. No other wildcards supported.
       repositories: ["*"]
       permissions: ["packages:read"]
+
+    # allow write access only for release pipelines on main branch
+    - name: "release-publisher"
+      match:
+        - claim: pipeline_slug
+          valuePattern: ".*-release"
+        - claim: build_branch
+          value: "main"
+      repositories: ["release-tools", "shared-infra"]
+      permissions: ["contents:write", "packages:write"]
 ```
 
 [github-token-permissions]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token


### PR DESCRIPTION
## Purpose

Document the claim-based access control feature for organization profiles, enabling operators to restrict which Buildkite pipelines can use specific profiles. This addresses a key limitation where organization profiles were previously available to all pipelines without restriction.

The feature supports use cases like:
- Publishing pipelines that require write access to shared repositories
- Production deployment pipelines with elevated permissions
- Cross-cutting policies based on pipeline naming conventions or branch restrictions

## Context

- Upstream implementation: https://github.com/chinmina/chinmina-bridge/pull/131
- Adds a new guide covering use cases, match rule patterns, and troubleshooting
- Expands the organization profile reference with configuration for `match` rules and allowed JWT claims
- Updates observability documentation with audit log examples for match success/failure scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide explaining organization profile-based pipeline access control using JWT claim matching, match rule patterns, request flow, troubleshooting, and auditing
  * Expanded audit log docs with additional fields, multiple JSON examples, and a security note about generic HTTP errors vs. detailed audit logs
  * Updated introduction and reference docs to describe match-aware profiles, allowed claims, and example usage

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->