### PR TITLE
docs: rename plugin prefix from repo: to pipeline:

### DIFF
--- a/src/content/docs/guides/buildkite-integration.mdx
+++ b/src/content/docs/guides/buildkite-integration.mdx
@@ -84,7 +84,7 @@ steps:
       # GITHUB_TOKEN is automatically available
       gh release download --repo myorg/myrepo --pattern "*.zip"
     plugins:
-      - chinmina/chinmina-token#v1.2.0:
+      - chinmina/chinmina-token#v1.3.0:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
           environment:
@@ -112,7 +112,7 @@ steps:
       # Deploy using different token with elevated permissions
       gh release create --repo myorg/releases "$VERSION"
     plugins:
-      - chinmina/chinmina-token#v1.2.0:
+      - chinmina/chinmina-token#v1.3.0:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
           environment:
@@ -131,7 +131,7 @@ an `environment` parameter, it adds the `chinmina_token` script to PATH.
 ```yml
 steps:
   - plugins:
-      - chinmina/chinmina-token#v1.2.0:
+      - chinmina/chinmina-token#v1.3.0:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
 ```
@@ -178,7 +178,7 @@ to authenticate with GitHub using tokens from Chinmina Bridge.
 steps:
   - command: git clone https://github.com/myorg/private-repo.git
     plugins:
-      - chinmina/chinmina-git-credentials#v1.0.2:
+      - chinmina/chinmina-git-credentials#v1.4.0:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
 ```
@@ -264,7 +264,7 @@ pipeline settings.
     ```bash
     # Chinmina Token plugin
     plugin_repo="https://github.com/chinmina/chinmina-token-buildkite-plugin.git"
-    plugin_version="v1.2.0"
+    plugin_version="v1.3.0"
     plugin_dir="/buildkite/plugins/chinmina-token-buildkite-plugin"
 
     [[ -d "${plugin_dir}" ]] && rm -rf "${plugin_dir}"
@@ -278,7 +278,7 @@ pipeline settings.
 
     # Chinmina Git Credentials plugin
     plugin_repo="https://github.com/chinmina/chinmina-git-credentials-buildkite-plugin.git"
-    plugin_version="v1.0.2"
+    plugin_version="v1.4.0"
     plugin_dir="/buildkite/plugins/chinmina-git-credentials-buildkite-plugin"
 
     [[ -d "${plugin_dir}" ]] && rm -rf "${plugin_dir}"
@@ -312,7 +312,7 @@ pipeline settings.
 
     ```yml
     plugins:
-      - chinmina/chinmina-token#v1.2.0:
+      - chinmina/chinmina-token#v1.3.0:
           environment:
             - GITHUB_TOKEN=pipeline:default
     ```

--- a/src/content/docs/guides/buildkite-integration.mdx
+++ b/src/content/docs/guides/buildkite-integration.mdx
@@ -88,7 +88,7 @@ steps:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
           environment:
-            - GITHUB_TOKEN=repo:default
+            - GITHUB_TOKEN=pipeline:default
 ```
 
 :::tip
@@ -116,11 +116,11 @@ steps:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
           environment:
-            - GITHUB_TOKEN=repo:release        # pipeline profile
+            - GITHUB_TOKEN=pipeline:release        # pipeline profile
             - GITHUB_NPM_TOKEN=org:npm-packages # organization profile
 ```
 
-Profile prefixes (`repo:`, `org:`) identify the profile type for the plugin. Pipeline profiles (`repo:`) grant permissions to the pipeline's repository, while organization profiles (`org:`) grant access to specific repositories across the organization.
+Profile prefixes (`pipeline:`, `org:`) identify the profile type for the plugin. Pipeline profiles (`pipeline:`) grant permissions to the pipeline's repository, while organization profiles (`org:`) grant access to specific repositories across the organization.
 
 ### Library mode (dynamic)
 
@@ -147,10 +147,10 @@ else
 fi
 
 # Get a token for pipeline repository with elevated permissions
-export GITHUB_TOKEN=$(chinmina_token "repo:release")
+export GITHUB_TOKEN=$(chinmina_token "pipeline:release")
 
 # Or get a token with default pipeline permissions
-export GITHUB_TOKEN=$(chinmina_token "repo:default")
+export GITHUB_TOKEN=$(chinmina_token "pipeline:default")
 
 # Use with gh CLI
 gh release download --repo "${repo}" \
@@ -314,7 +314,7 @@ pipeline settings.
     plugins:
       - chinmina/chinmina-token#v1.2.0:
           environment:
-            - GITHUB_TOKEN=repo:default
+            - GITHUB_TOKEN=pipeline:default
     ```
 
     :::note

--- a/src/content/docs/guides/customizing-permissions.mdx
+++ b/src/content/docs/guides/customizing-permissions.mdx
@@ -93,11 +93,11 @@ steps:
     plugins:
       - chinmina/chinmina-token#v1.2.0:
           environment:
-            - GITHUB_TOKEN=repo:pr-commenter
+            - GITHUB_TOKEN=pipeline:pr-commenter
 ```
 
 Profile prefixes:
-- `repo:profile-name` → pipeline profile
+- `pipeline:profile-name` → pipeline profile
 - `org:profile-name` → organization profile
 
 #### Library mode (dynamic)
@@ -109,9 +109,9 @@ steps:
   - command: |
       # Select profile based on branch
       if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
-        export GITHUB_TOKEN=$(chinmina_token "repo:release")
+        export GITHUB_TOKEN=$(chinmina_token "pipeline:release")
       else
-        export GITHUB_TOKEN=$(chinmina_token "repo:default")
+        export GITHUB_TOKEN=$(chinmina_token "pipeline:default")
       fi
 
       gh release create "$TAG" --notes "Release $TAG"

--- a/src/content/docs/guides/customizing-permissions.mdx
+++ b/src/content/docs/guides/customizing-permissions.mdx
@@ -91,7 +91,7 @@ steps:
   - label: "Comment on PR"
     command: gh pr comment $BUILDKITE_PULL_REQUEST --body "Tests passed!"
     plugins:
-      - chinmina/chinmina-token#v1.2.0:
+      - chinmina/chinmina-token#v1.3.0:
           environment:
             - GITHUB_TOKEN=pipeline:pr-commenter
 ```
@@ -116,7 +116,7 @@ steps:
 
       gh release create "$TAG" --notes "Release $TAG"
     plugins:
-      - chinmina/chinmina-token#v1.2.0: {}
+      - chinmina/chinmina-token#v1.3.0: {}
 ```
 
 ### With the Git Credentials plugin
@@ -127,7 +127,7 @@ The [Chinmina Git Credentials plugin][credentials-plugin] can use profiles for G
 steps:
   - command: git clone https://github.com/myorg/private-plugin.git
     plugins:
-      - chinmina/chinmina-git-credentials#v1.0.2:
+      - chinmina/chinmina-git-credentials#v1.4.0:
           profile: org:shared-plugins
 ```
 

--- a/src/content/docs/reference/api/pipeline-git-credentials.md
+++ b/src/content/docs/reference/api/pipeline-git-credentials.md
@@ -55,7 +55,7 @@ The optional `{profile}` path parameter specifies which pipeline profile to use:
 - `/git-credentials/{profile-name}`: Uses the named pipeline profile
 
 Profile names are used directly in the path. The API does not use prefixes
-(prefixes like `repo:` are part of the plugin interface only).
+(prefixes like `pipeline:` are part of the plugin interface only).
 
 Examples:
 

--- a/src/content/docs/reference/api/pipeline-token.md
+++ b/src/content/docs/reference/api/pipeline-token.md
@@ -53,7 +53,7 @@ The optional `{profile}` path parameter specifies which pipeline profile to use:
 - `/token/{profile-name}`: Uses the named pipeline profile
 
 Profile names are used directly in the path. The API does not use prefixes
-(prefixes like `repo:` are part of the plugin interface only).
+(prefixes like `pipeline:` are part of the plugin interface only).
 
 Examples:
 

--- a/src/content/docs/reference/profiles/pipeline.md
+++ b/src/content/docs/reference/profiles/pipeline.md
@@ -96,12 +96,12 @@ The special profile name `default` accesses `pipeline.defaults` permissions.
 
 ### From Buildkite plugins
 
-The [Chinmina Token plugin][chinmina-token] and [Chinmina Git Credentials plugin][credentials-plugin] use the `repo:` prefix to identify pipeline profiles:
+The [Chinmina Token plugin][chinmina-token] and [Chinmina Git Credentials plugin][credentials-plugin] use the `pipeline:` prefix to identify pipeline profiles:
 
 ```yaml
 environment:
-  - GITHUB_TOKEN=repo:default       # pipeline defaults
-  - PR_TOKEN=repo:pr-commenter      # named pipeline profile
+  - GITHUB_TOKEN=pipeline:default       # pipeline defaults
+  - PR_TOKEN=pipeline:pr-commenter      # named pipeline profile
 ```
 
 The plugins translate these to appropriate API paths (`/token/default`, `/token/pr-commenter`).


### PR DESCRIPTION
## Purpose

Aligns plugin documentation with the nomenclature change in chinmina-token and chinmina-git-credentials plugins, where the profile prefix is changing from `repo:` to `pipeline:` to better reflect that these profiles are "pipeline profiles" not "repository profiles."

This documentation update prepares users for the v2.0.0 plugin releases where the `repo:` prefix will be removed entirely.

## Context

- Related to: https://github.com/chinmina/chinmina-token-buildkite-plugin/issues/7
- The plugins are renaming the prefix to improve clarity and consistency with the "pipeline profile" terminology used throughout Chinmina
- Documentation is updated across all guides and API reference pages where the plugin prefix appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation guides and API references to reflect the correct `pipeline:` prefix terminology for profile configurations instead of the previous `repo:` prefix.
  * Clarified profile examples and environment variable configurations across integration guides and permission customization documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->