### PR TITLE
docs: update plugin versions to v1.3.1 and v1.4.1

### DIFF
--- a/.claude/skills/update-plugin-versions/SKILL.md
+++ b/.claude/skills/update-plugin-versions/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: update-plugin-versions
+description: Fetch latest release versions of chinmina-token and chinmina-git-credentials Buildkite plugins and update all references in the documentation. Use when updating plugin versions or checking for new releases.
+allowed-tools: Bash, Read, Edit
+---
+
+# Update Plugin Versions
+
+Updates all references to chinmina Buildkite plugins in the documentation to their latest released versions.
+
+## Plugins Updated
+
+1. **chinmina-token**: `chinmina/chinmina-token-buildkite-plugin`
+2. **chinmina-git-credentials**: `chinmina/chinmina-git-credentials-buildkite-plugin`
+
+## Workflow
+
+The skill uses three scripts that work together:
+
+### 1. Get Latest Versions
+
+First, fetch the latest versions from GitHub:
+
+```bash
+.claude/skills/update-plugin-versions/scripts/get-latest-versions.sh
+```
+
+**Output:** JSON with plugin names and versions
+```json
+{
+  "chinmina-token": "v1.3.1",
+  "chinmina-git-credentials": "v1.4.1"
+}
+```
+
+### 2. Update Simple References (Deterministic)
+
+For each plugin, update the standard `chinmina/plugin-name#vX.Y.Z` format:
+
+```bash
+.claude/skills/update-plugin-versions/scripts/update-simple-refs.sh chinmina-token v1.3.1
+.claude/skills/update-plugin-versions/scripts/update-simple-refs.sh chinmina-git-credentials v1.4.1
+```
+
+**Output:** List of files updated with counts
+
+This handles the common case (pipeline plugin references) automatically.
+
+### 3. Find Remaining References (Context for LLM)
+
+Check for any remaining version references that need manual review:
+
+```bash
+.claude/skills/update-plugin-versions/scripts/find-version-refs.sh chinmina-token v1.3.1
+.claude/skills/update-plugin-versions/scripts/find-version-refs.sh chinmina-git-credentials v1.4.1
+```
+
+**Output:** `file:line:context` showing outdated references with surrounding code
+
+This shows bootstrap hooks, variable assignments, or other non-standard formats that need contextual understanding.
+
+### 4. Manual Updates (LLM)
+
+For any references found in step 3:
+- Read the file to understand the format
+- Use Edit tool to update the version in context
+- The LLM adapts to whatever format is used (bash variables, etc.)
+
+## Design Philosophy
+
+**Scripts encode deterministic actions:**
+- Fetching versions from GitHub
+- Replacing standard plugin#version format
+- Finding references with context
+
+**LLM handles contextual understanding:**
+- Understanding non-standard formats (bootstrap hooks, etc.)
+- Making targeted edits in appropriate context
+- Adapting to new patterns without script changes
+
+This keeps scripts simple and maintainable while leveraging LLM flexibility for edge cases.
+
+## Requirements
+
+- GitHub CLI (`gh`) must be installed and authenticated
+- Must be run from the repository root

--- a/.claude/skills/update-plugin-versions/scripts/find-version-refs.sh
+++ b/.claude/skills/update-plugin-versions/scripts/find-version-refs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Find references to plugin that aren't the simple plugin#version format
+# Usage: find-version-refs.sh <plugin-name> <target-version>
+# Example: find-version-refs.sh chinmina-token v1.3.1
+#
+# Output: file:line with 3 lines of context before/after
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <plugin-name> <target-version>" >&2
+  echo "Example: $0 chinmina-token v1.3.1" >&2
+  exit 1
+fi
+
+plugin_name="$1"
+target_version="$2"
+
+docs_dir="src/content/docs"
+if [[ ! -d "$docs_dir" ]]; then
+  echo "Error: Documentation directory not found: $docs_dir" >&2
+  exit 1
+fi
+
+# Step 1: Find all lines with plugin name
+# Step 2: Exclude simple format with target version
+matches=$(grep -rn "${plugin_name}" "$docs_dir" | grep -v "chinmina/${plugin_name}#${target_version}")
+
+if [[ -z "$matches" ]]; then
+  echo "No additional references found for ${plugin_name}"
+  exit 0
+fi
+
+echo "=== References to ${plugin_name} (excluding chinmina/${plugin_name}#${target_version}) ==="
+echo
+
+# Step 3: For each match, show the line with context
+echo "$matches" | while IFS=: read -r file line rest; do
+  echo "${file}:${line}"
+
+  # Show 3 lines before and after, with line numbers
+  start=$((line - 3))
+  if [[ $start -lt 1 ]]; then start=1; fi
+
+  sed -n "${start},$((line + 3))p" "$file" | nl -v "$start" -w 5 -s ": "
+  echo
+done

--- a/.claude/skills/update-plugin-versions/scripts/get-latest-versions.sh
+++ b/.claude/skills/update-plugin-versions/scripts/get-latest-versions.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Fetch latest plugin versions from GitHub releases
+# Output: JSON object with plugin names and versions
+
+set -euo pipefail
+
+token_version=$(gh api repos/chinmina/chinmina-token-buildkite-plugin/releases/latest --jq '.tag_name')
+git_creds_version=$(gh api repos/chinmina/chinmina-git-credentials-buildkite-plugin/releases/latest --jq '.tag_name')
+
+if [[ -z "$token_version" ]] || [[ -z "$git_creds_version" ]]; then
+  echo '{"error": "Failed to fetch versions"}' >&2
+  exit 1
+fi
+
+cat <<EOF
+{
+  "chinmina-token": "$token_version",
+  "chinmina-git-credentials": "$git_creds_version"
+}
+EOF

--- a/.claude/skills/update-plugin-versions/scripts/update-simple-refs.sh
+++ b/.claude/skills/update-plugin-versions/scripts/update-simple-refs.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Update simple plugin references: chinmina/plugin-name#vX.Y.Z
+# Usage: update-simple-refs.sh <plugin-name> <target-version>
+# Example: update-simple-refs.sh chinmina-token v1.3.1
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <plugin-name> <target-version>" >&2
+  echo "Example: $0 chinmina-token v1.3.1" >&2
+  exit 1
+fi
+
+plugin_name="$1"
+target_version="$2"
+
+# Validate version format
+if [[ ! "$target_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: Invalid version format. Expected vX.Y.Z, got: $target_version" >&2
+  exit 1
+fi
+
+docs_dir="src/content/docs"
+if [[ ! -d "$docs_dir" ]]; then
+  echo "Error: Documentation directory not found: $docs_dir" >&2
+  exit 1
+fi
+
+# Find current versions for this plugin
+pattern="chinmina/${plugin_name}#v"
+current_versions=$(grep -rh "${pattern}" "$docs_dir" | grep -o "v[0-9]\+\.[0-9]\+\.[0-9]\+" | sort -u)
+
+if [[ -z "$current_versions" ]]; then
+  echo "No references found for ${plugin_name}"
+  exit 0
+fi
+
+# Track updates
+total_updates=0
+updated_files=()
+
+# Update each outdated version
+for old_version in $current_versions; do
+  if [[ "$old_version" == "$target_version" ]]; then
+    continue
+  fi
+
+  # Find and update files
+  while IFS= read -r file || [[ -n "$file" ]]; do
+    if [[ -n "$file" ]]; then
+      sed -i.bak "s|chinmina/${plugin_name}#${old_version}|chinmina/${plugin_name}#${target_version}|g" "$file"
+      rm "${file}.bak"
+      updated_files+=("$file")
+      (( ++total_updates ))
+    fi
+  done < <(grep -rl "chinmina/${plugin_name}#${old_version}" "$docs_dir")
+done
+
+# Output results
+if [[ $total_updates -eq 0 ]]; then
+  echo "All ${plugin_name} references already at ${target_version}"
+else
+  echo "Updated ${total_updates} reference(s) to ${target_version}:"
+  printf '%s\n' "${updated_files[@]}" | sort -u
+fi

--- a/src/content/docs/guides/buildkite-integration.mdx
+++ b/src/content/docs/guides/buildkite-integration.mdx
@@ -84,7 +84,7 @@ steps:
       # GITHUB_TOKEN is automatically available
       gh release download --repo myorg/myrepo --pattern "*.zip"
     plugins:
-      - chinmina/chinmina-token#v1.3.0:
+      - chinmina/chinmina-token#v1.3.1:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
           environment:
@@ -112,7 +112,7 @@ steps:
       # Deploy using different token with elevated permissions
       gh release create --repo myorg/releases "$VERSION"
     plugins:
-      - chinmina/chinmina-token#v1.3.0:
+      - chinmina/chinmina-token#v1.3.1:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
           environment:
@@ -131,7 +131,7 @@ an `environment` parameter, it adds the `chinmina_token` script to PATH.
 ```yml
 steps:
   - plugins:
-      - chinmina/chinmina-token#v1.3.0:
+      - chinmina/chinmina-token#v1.3.1:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
 ```
@@ -178,7 +178,7 @@ to authenticate with GitHub using tokens from Chinmina Bridge.
 steps:
   - command: git clone https://github.com/myorg/private-repo.git
     plugins:
-      - chinmina/chinmina-git-credentials#v1.4.0:
+      - chinmina/chinmina-git-credentials#v1.4.1:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
 ```
@@ -264,7 +264,7 @@ pipeline settings.
     ```bash
     # Chinmina Token plugin
     plugin_repo="https://github.com/chinmina/chinmina-token-buildkite-plugin.git"
-    plugin_version="v1.3.0"
+    plugin_version="v1.3.1"
     plugin_dir="/buildkite/plugins/chinmina-token-buildkite-plugin"
 
     [[ -d "${plugin_dir}" ]] && rm -rf "${plugin_dir}"
@@ -278,7 +278,7 @@ pipeline settings.
 
     # Chinmina Git Credentials plugin
     plugin_repo="https://github.com/chinmina/chinmina-git-credentials-buildkite-plugin.git"
-    plugin_version="v1.4.0"
+    plugin_version="v1.4.1"
     plugin_dir="/buildkite/plugins/chinmina-git-credentials-buildkite-plugin"
 
     [[ -d "${plugin_dir}" ]] && rm -rf "${plugin_dir}"
@@ -312,7 +312,7 @@ pipeline settings.
 
     ```yml
     plugins:
-      - chinmina/chinmina-token#v1.3.0:
+      - chinmina/chinmina-token#v1.3.1:
           environment:
             - GITHUB_TOKEN=pipeline:default
     ```

--- a/src/content/docs/guides/customizing-permissions.mdx
+++ b/src/content/docs/guides/customizing-permissions.mdx
@@ -91,7 +91,7 @@ steps:
   - label: "Comment on PR"
     command: gh pr comment $BUILDKITE_PULL_REQUEST --body "Tests passed!"
     plugins:
-      - chinmina/chinmina-token#v1.3.0:
+      - chinmina/chinmina-token#v1.3.1:
           environment:
             - GITHUB_TOKEN=pipeline:pr-commenter
 ```
@@ -116,7 +116,7 @@ steps:
 
       gh release create "$TAG" --notes "Release $TAG"
     plugins:
-      - chinmina/chinmina-token#v1.3.0: {}
+      - chinmina/chinmina-token#v1.3.1: {}
 ```
 
 ### With the Git Credentials plugin
@@ -127,7 +127,7 @@ The [Chinmina Git Credentials plugin][credentials-plugin] can use profiles for G
 steps:
   - command: git clone https://github.com/myorg/private-plugin.git
     plugins:
-      - chinmina/chinmina-git-credentials#v1.4.0:
+      - chinmina/chinmina-git-credentials#v1.4.1:
           profile: org:shared-plugins
 ```
 


### PR DESCRIPTION
## Purpose

Updates documentation to reference the latest releases of the Buildkite plugins, ensuring users install the current stable versions with any bug fixes or improvements included in these releases.

Adds automation to simplify future plugin version updates, reducing manual effort and potential for errors when new releases are published.

## Context

- chinmina-token updated from v1.3.0 to v1.3.1
- chinmina-git-credentials updated from v1.4.0 to v1.4.1
- Changes applied to plugin version references in integration and permissions documentation
- New skill (`update-plugin-versions`) queries GitHub for latest releases and updates all documentation references automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Buildkite plugin version references from v1.3.0→v1.3.1 (chinmina-token) and v1.4.0→v1.4.1 (chinmina-git-credentials) across integration and permissions guides.

* **New Features**
  * Added automated workflow for fetching latest plugin versions and updating documentation references consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->