### PR TITLE
docs: document API and observability changes from chinmina-bridge #240–#255

### DIFF
--- a/src/content/docs/guides/deployment-example.md
+++ b/src/content/docs/guides/deployment-example.md
@@ -183,13 +183,13 @@ Chinmina runs in a Chainguard static container containing only the executable an
 
 ### Audit logging
 
-All token requests are logged to stdout at the `audit` log level with success or failure status. These audit logs provide non-repudiation for the system and cannot be disabled. Logs are forwarded to the organization's log aggregation platform for centralized monitoring and analysis.
+All token requests are logged to stdout at `INFO` level with success or failure status. These audit logs provide non-repudiation for the system and cannot be disabled — they are written unconditionally regardless of log level configuration. Use `type=audit` to identify audit entries in queries and alerts. Logs are forwarded to the organization's log aggregation platform for centralized monitoring and analysis.
 
 Example audit log entry:
 
 ```json
 {
-  "level": "audit",
+  "level": "INFO",
   "request": {
     "method": "POST",
     "path": "/token",

--- a/src/content/docs/guides/observability.md
+++ b/src/content/docs/guides/observability.md
@@ -3,7 +3,7 @@ title: Observability
 description: Using OpenTelemetry and logging to understand and diagnose Chinmina.
 ---
 
-Chinmina produces traces and metrics via OpenTelemetry, and logs to stdout via [zerolog][zerolog].
+Chinmina produces traces and metrics via OpenTelemetry, and logs to stdout in JSON format.
 
 For audit log details, see the [auditing reference](../reference/auditing). For complete telemetry technical details, see the [telemetry reference](../reference/telemetry).
 
@@ -12,7 +12,8 @@ For audit log details, see the [auditing reference](../reference/auditing). For 
 Set `OBSERVE_ENABLED=true` to enable telemetry collection.
 
 Choose an exporter type with `OBSERVE_TYPE`:
-- `"grpc"` (default): Send to an OpenTelemetry collector via gRPC
+- `"grpc"` (default): Send to an OpenTelemetry collector via gRPC (port 4317)
+- `"http"`: Send via HTTP/protobuf OTLP (port 4318). Use this in environments where gRPC is blocked by HTTP proxies or load balancers.
 - `"stdout"`: Write to standard output (development only)
 
 ### Minimal configuration
@@ -23,6 +24,14 @@ For gRPC export to a collector:
 OBSERVE_ENABLED=true
 OBSERVE_TYPE=grpc
 OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317
+```
+
+For HTTP export:
+
+```bash
+OBSERVE_ENABLED=true
+OBSERVE_TYPE=http
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318
 ```
 
 For stdout export during development:
@@ -183,4 +192,28 @@ Internal span: refresh_organization_profile
 - Keyset refresh warnings: verify IAM permissions for Secrets Manager and KMS, then check service health
 - Persistent errors with no configuration changes: check Valkey connectivity and data integrity
 
-[zerolog]: https://github.com/rs/zerolog/
+## Continuous profiling
+
+[Grafana Pyroscope][pyroscope] provides continuous profiling: CPU time, memory allocations, goroutine counts, mutex contention, and block profiles sampled in production. Where OTel traces show that a request was slow, profiling shows which code path consumed the time.
+
+When enabled, each active OTel span is linked to its corresponding Pyroscope profile. In the Pyroscope UI, you can navigate directly from a slow trace to the profile recorded during that span.
+
+Profiling is disabled by default. Enable it with:
+
+```bash
+OBSERVE_PYROSCOPE_ENABLED=true
+OBSERVE_PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
+```
+
+For authenticated targets such as Grafana Cloud:
+
+```bash
+OBSERVE_PYROSCOPE_ENABLED=true
+OBSERVE_PYROSCOPE_SERVER_ADDRESS=https://profiles-prod-001.grafana.net
+OBSERVE_PYROSCOPE_BASIC_AUTH_USER=123456
+OBSERVE_PYROSCOPE_BASIC_AUTH_PASSWORD=glc_...
+```
+
+See the [configuration reference](../reference/configuration#pyroscope-continuous-profiling) for all `OBSERVE_PYROSCOPE_*` variables.
+
+[pyroscope]: https://grafana.com/oss/pyroscope/

--- a/src/content/docs/reference/api/organization-token.md
+++ b/src/content/docs/reference/api/organization-token.md
@@ -60,10 +60,29 @@ The request body is expected to be empty.
 
 ```json
 {
+  "organizationSlug": "my-org",
+  "profile": "release-publisher",
+  "repositoryUrl": "",
+  "repositories": {"names": ["owner/release-tools", "owner/shared-infra"]},
+  "permissions": ["metadata:read", "contents:write", "packages:write"],
   "token": "ghs_...",
-  "expiresAt": "2025-01-15T10:30:00Z"
+  "hashedToken": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "expiry": "2025-12-21T10:00:00Z"
 }
 ```
+
+For wildcard profiles (configured with `repositories: ["*"]`), the `repositories` field is `{"wildcard": true}` rather than a named list.
+
+| Field              | Type   | Description                                                             |
+| ------------------ | ------ | ----------------------------------------------------------------------- |
+| `organizationSlug` | string | Buildkite organization from JWT claims                                  |
+| `profile`          | string | Profile identifier that was used                                        |
+| `repositoryUrl`    | string | Always empty for organization profile requests                          |
+| `repositories`     | object | Repositories the token has access to. Either `{"wildcard": true}` (all repositories accessible to the GitHub App installation) or `{"names": ["owner/repo", ...]}` (specific named repositories). |
+| `permissions`      | array  | Permissions granted. Always includes `metadata:read` plus configured permissions. |
+| `token`            | string | GitHub installation token (format: `ghs_...`)                           |
+| `hashedToken`      | string | SHA-256 hash of the token, base64-encoded (`base64(SHA-256(token))`). Use to correlate with [GitHub organisation audit log events][gh-audit-token] for the same token. |
+| `expiry`           | string | ISO 8601 timestamp when token expires                                   |
 
 ### Empty response (200 OK)
 
@@ -78,3 +97,5 @@ When the requested repository is not in the profile's repository list, the endpo
 | 403 Forbidden    | Insufficient JWT claims       | JSON error |
 | 404 Not Found    | Profile does not exist        | JSON error |
 | 500 Server Error | Token vending or GitHub error | JSON error |
+
+[gh-audit-token]: https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/identifying-audit-log-events-performed-by-an-access-token

--- a/src/content/docs/reference/api/pipeline-token.md
+++ b/src/content/docs/reference/api/pipeline-token.md
@@ -79,9 +79,10 @@ When a token is successfully vended, the response is a JSON object:
   "organizationSlug": "my-org",
   "profile": "org:default",
   "repositoryUrl": "https://github.com/owner/repository",
-  "repositories": ["owner/repository"],
+  "repositories": {"names": ["owner/repository"]},
   "permissions": ["metadata:read", "contents:read"],
   "token": "ghs_...",
+  "hashedToken": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
   "expiry": "2025-12-21T10:00:00Z"
 }
 ```
@@ -91,9 +92,10 @@ When a token is successfully vended, the response is a JSON object:
 | `organizationSlug` | string | Buildkite organization from JWT claims                                  |
 | `profile`          | string | Profile identifier that was used                                        |
 | `repositoryUrl`    | string | The requested repository URL: this will always be empty                 |
-| `repositories`     | array  | List of repository names the token has access to (format: `owner/repo`) |
+| `repositories`     | object | Repositories the token has access to. Either `{"wildcard": true}` (all repositories accessible to the GitHub App installation) or `{"names": ["owner/repo", ...]}` (specific named repositories). |
 | `permissions`      | array  | Permissions granted. Always includes `metadata:read` plus configured permissions. |
 | `token`            | string | GitHub installation token (format: `ghs_...`)                           |
+| `hashedToken`      | string | SHA-256 hash of the token, base64-encoded (`base64(SHA-256(token))`). Use to correlate with [GitHub organisation audit log events][gh-audit-token] for the same token. |
 | `expiry`           | string | ISO 8601 timestamp when token expires                                   |
 
 ### Error responses
@@ -105,3 +107,5 @@ When a token is successfully vended, the response is a JSON object:
 | `404 Not Found`                | Profile does not exist or failed validation                     |
 | `413 Request Entity Too Large` | Request body exceeds 20 KB                                      |
 | `500 Internal Server Error`    | Token vending failure, Buildkite API error, or GitHub API error |
+
+[gh-audit-token]: https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/identifying-audit-log-events-performed-by-an-access-token

--- a/src/content/docs/reference/auditing.md
+++ b/src/content/docs/reference/auditing.md
@@ -17,7 +17,7 @@ HTTP error responses return generic messages like "Forbidden" to avoid leaking p
 
 ## Log format
 
-Logs are written to stdout using zerolog at the "audit" log level. All audit logs are in single-line JSON format.
+Logs are written to stdout at `INFO` level. All audit logs are in single-line JSON format.
 
 Related fields are grouped into nested JSON objects by concern: `request`, `pipeline`, `authorization`, and `token`. The `request` and `authorization` sections are always present. The `pipeline` and `token` sections are omitted when all their fields are empty — for example, when a request fails before JWT validation completes or before a token operation begins.
 
@@ -27,7 +27,11 @@ Related fields are grouped into nested JSON objects by concern: `request`, `pipe
 
 ###### `level`
 
-Always `"audit"`.
+Always `"INFO"`. Audit log entries are written unconditionally and are not subject to log level configuration.
+
+###### `type`
+
+Always `"audit"`. Use this field to identify audit log entries in queries and alerts.
 
 ###### `message`
 
@@ -141,6 +145,10 @@ The GitHub token expiry time as an [RFC-3339][rfc-3339] date-time string. Only p
 
 The time the GitHub token will remain valid at the time of logging, in milliseconds. Only present on successful token issuance.
 
+###### `hash`
+
+SHA-256 hash of the issued token, base64-encoded (`base64(SHA-256(token))`). Only present on successful token issuance. Use this to correlate Chinmina audit events with [GitHub organisation audit log events][gh-audit-token] for the same token.
+
 ###### `matches`
 
 Array of matched claim/value pairs on successful profile access. Each element contains `claim` and `value` fields.
@@ -161,7 +169,7 @@ HTTP error responses return generic messages like "Forbidden" to avoid leaking p
 
 ```json
 {
-  "level": "audit",
+  "level": "INFO",
   "request": {
     "method": "POST",
     "path": "/git-credentials",
@@ -188,7 +196,8 @@ HTTP error responses return generic messages like "Forbidden" to avoid leaking p
     "repositories": ["https://github.com/example-org/example-repo.git"],
     "permissions": ["contents:read"],
     "expiry": "2025-01-20T05:09:45Z",
-    "expiryRemaining": 1306372
+    "expiryRemaining": 1306372,
+    "hash": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
   },
   "type": "audit",
   "time": "2025-01-20T04:47:00Z",
@@ -200,7 +209,7 @@ HTTP error responses return generic messages like "Forbidden" to avoid leaking p
 
 ```json
 {
-  "level": "audit",
+  "level": "INFO",
   "request": {
     "method": "POST",
     "path": "/organization/token/release-publisher",
@@ -230,7 +239,8 @@ HTTP error responses return generic messages like "Forbidden" to avoid leaking p
     "repositories": ["https://github.com/example-org/release-tools.git"],
     "permissions": ["contents:write", "packages:write"],
     "expiry": "2025-01-20T05:09:45Z",
-    "expiryRemaining": 1306372
+    "expiryRemaining": 1306372,
+    "hash": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
   },
   "type": "audit",
   "time": "2025-01-20T04:47:00Z",
@@ -242,7 +252,7 @@ HTTP error responses return generic messages like "Forbidden" to avoid leaking p
 
 ```json
 {
-  "level": "audit",
+  "level": "INFO",
   "request": {
     "method": "POST",
     "path": "/organization/token/release-publisher",
@@ -281,3 +291,4 @@ HTTP error responses return generic messages like "Forbidden" to avoid leaking p
 ```
 
 [rfc-3339]: https://pkg.go.dev/time#RFC3339
+[gh-audit-token]: https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/identifying-audit-log-events-performed-by-an-access-token

--- a/src/content/docs/reference/configuration.md
+++ b/src/content/docs/reference/configuration.md
@@ -272,11 +272,9 @@ If the Open Telemetry target does not support metrics (e.g. Jaeger), set this to
 
 ###### `OBSERVE_TYPE`
 
-_(options: `grpc | stdout` default: `grpc`)_
+_(options: `grpc | http | stdout` default: `grpc`)_
 
-Set the outgoing transport to use for telemetry. GRPC is the default; `stdout`
-is only really useful for development situations where a telemetry server is not
-available.
+Set the outgoing transport to use for telemetry. `grpc` (port 4317) is the default. `http` uses HTTP/protobuf OTLP (port 4318) and is useful in environments where gRPC is blocked by HTTP proxies or load balancers. `stdout` writes telemetry to standard output and is only useful during development.
 
 ###### `OBSERVE_OTEL_LOG_LEVEL`
 
@@ -322,6 +320,34 @@ When true, outgoing HTTP requests will be annotated with details of the
 connection process, e.g. DNS lookup time. Only effective when HTTP transport
 tracing is enabled.
 
+### Pyroscope continuous profiling
+
+Optional continuous profiling via [Grafana Pyroscope][pyroscope]. When enabled, CPU, allocation, goroutine, mutex, and block profiles are sent to the configured Pyroscope server. Each active OTel span is linked to its corresponding Pyroscope profile, enabling navigation from a trace to the profile recorded during that span.
+
+Startup validation fails immediately if `OBSERVE_PYROSCOPE_ENABLED=true` is set without a server address.
+
+###### `OBSERVE_PYROSCOPE_ENABLED`
+
+_(default: `false`)_
+
+Enable continuous profiling. Requires `OBSERVE_PYROSCOPE_SERVER_ADDRESS`.
+
+###### `OBSERVE_PYROSCOPE_SERVER_ADDRESS`
+
+The Pyroscope server URL (e.g., `http://pyroscope:4040` or a Grafana Cloud endpoint). Required when `OBSERVE_PYROSCOPE_ENABLED` is `true`.
+
+###### `OBSERVE_PYROSCOPE_BASIC_AUTH_USER`
+
+HTTP Basic Auth username for authenticated Pyroscope targets (e.g., Grafana Cloud). Leave unset for unauthenticated local servers.
+
+###### `OBSERVE_PYROSCOPE_BASIC_AUTH_PASSWORD`
+
+HTTP Basic Auth password for authenticated Pyroscope targets.
+
+###### `OBSERVE_PYROSCOPE_EXPERIMENT`
+
+An optional label attached to profiling data as an `experiment` tag. Useful for A/B comparisons at runtime without requiring a redeploy. Overrides any compile-time experiment tag.
+
 ###### `OTEL_EXPORTER_OTLP_ENDPOINT`
 
 _(default: `http://localhost:4317`)_
@@ -340,3 +366,4 @@ variables available.
 [profiles-config]: profiles/
 [pipeline-profile-config]: profiles/pipeline
 [org-profile-config]: profiles/organization
+[pyroscope]: https://grafana.com/oss/pyroscope/


### PR DESCRIPTION
## Purpose

Documents a batch of chinmina-bridge changes that shipped without corresponding documentation updates. The changes span three areas operators need to be aware of:

**Breaking API change.** The `repositories` field in `/token` and `/organization/token/{profile}` responses changed from an array to a JSON object (`{"wildcard": true}` or `{"names": [...]}`) in #250. Clients parsing this field need updating. The organization token endpoint also had no response body documentation at all; that gap is now filled.

**Auditing changes that affect log queries and alerting.** Audit entries moved to a nested JSON structure (#242), now emit at `INFO` level with a `type=audit` discriminator instead of a custom level (#252), and include a `token.hash` field for correlating Chinmina audit events with GitHub organisation audit log events for the same token (#248).

**New observability options.** `OBSERVE_TYPE=http` adds HTTP/protobuf OTLP export for environments where gRPC is blocked by proxies or load balancers (#251). Pyroscope continuous profiling is now available as an opt-in feature with span-to-profile linking in the Pyroscope UI, including support for authenticated targets such as Grafana Cloud (#245, #254).

## Context

Source changes:
- chinmina/chinmina-bridge#241
- chinmina/chinmina-bridge#242
- chinmina/chinmina-bridge#245
- chinmina/chinmina-bridge#247
- chinmina/chinmina-bridge#248
- chinmina/chinmina-bridge#250
- chinmina/chinmina-bridge#251
- chinmina/chinmina-bridge#252
- chinmina/chinmina-bridge#253
- chinmina/chinmina-bridge#254

The `VALKEY_IAM_*` vars (#241) and the logging backend migration from zerolog to `log/slog` (#247) were already documented or had only a stale reference to clean up; those are included in this branch but are not the primary focus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated audit logging documentation to clarify that logs are written at `INFO` level with type identifiers for easier querying.
  * Added HTTP/protobuf OTLP transport option (port 4318) for observability alongside existing gRPC support.
  * Introduced Grafana Pyroscope continuous profiling integration with configuration examples and span-to-profile linking.
  * Updated API response schemas with hashed token fields for audit log correlation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->