### PR TITLE
feat: serve raw markdown at .md routes for LLM consumption

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import starlight from "@astrojs/starlight"
 import starlightHeadingBadges from "starlight-heading-badges"
 
 import d2 from "astro-d2"
+import markdownPages from "./src/integrations/markdown-pages.mjs"
 
 // https://astro.build/config
 export default defineConfig({
@@ -85,5 +86,6 @@ export default defineConfig({
     d2({
       layout: "elk",
     }),
+    markdownPages(),
   ],
 })

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,65 @@ import starlightHeadingBadges from "starlight-heading-badges"
 import d2 from "astro-d2"
 import markdownPages from "./src/integrations/markdown-pages.mjs"
 
+const sidebar = [
+  {
+    label: "Introduction",
+    link: "introduction",
+  },
+  {
+    label: "Guides",
+    items: [
+      "guides/getting-started",
+      "guides/buildkite-integration",
+      "guides/customizing-permissions",
+      "guides/kms",
+      "guides/distributed-cache",
+      "guides/observability",
+      "guides/deployment-example",
+      "guides/verifying-releases",
+    ],
+  },
+  {
+    label: "Reference",
+    items: [
+      "reference/configuration",
+      "reference/git-credentials-format",
+      "reference/auditing",
+      {
+        label: "Telemetry",
+        items: [
+          "reference/telemetry",
+          "reference/telemetry/traces",
+          "reference/telemetry/metrics",
+        ],
+      },
+      {
+        label: "Profiles",
+        items: [
+          "reference/profiles",
+          "reference/profiles/pipeline",
+          "reference/profiles/organization",
+          "reference/profiles/matching",
+        ],
+      },
+      {
+        label: "API",
+        items: [
+          "reference/api/health-check-and-status",
+          "reference/api/pipeline-git-credentials",
+          "reference/api/pipeline-token",
+          "reference/api/organization-git-credentials",
+          "reference/api/organization-token",
+        ],
+      },
+    ],
+  },
+  {
+    label: "Contributing",
+    autogenerate: { directory: "contributing" },
+  },
+]
+
 // https://astro.build/config
 export default defineConfig({
   site: "https://chinmina.github.io",
@@ -24,68 +83,19 @@ export default defineConfig({
           href: "https://github.com/chinmina/chinmina-bridge",
         },
       ],
-      sidebar: [
-        {
-          label: "Introduction",
-          link: "introduction",
-        },
-        {
-          label: "Guides",
-          items: [
-            "guides/getting-started",
-            "guides/buildkite-integration",
-            "guides/customizing-permissions",
-            "guides/kms",
-            "guides/distributed-cache",
-            "guides/observability",
-            "guides/deployment-example",
-            "guides/verifying-releases",
-          ],
-        },
-        {
-          label: "Reference",
-          items: [
-            "reference/configuration",
-            "reference/git-credentials-format",
-            "reference/auditing",
-            {
-              label: "Telemetry",
-              items: [
-                "reference/telemetry",
-                "reference/telemetry/traces",
-                "reference/telemetry/metrics",
-              ],
-            },
-            {
-              label: "Profiles",
-              items: [
-                "reference/profiles",
-                "reference/profiles/pipeline",
-                "reference/profiles/organization",
-                "reference/profiles/matching",
-              ],
-            },
-            {
-              label: "API",
-              items: [
-                "reference/api/health-check-and-status",
-                "reference/api/pipeline-git-credentials",
-                "reference/api/pipeline-token",
-                "reference/api/organization-git-credentials",
-                "reference/api/organization-token",
-              ],
-            },
-          ],
-        },
-        {
-          label: "Contributing",
-          autogenerate: { directory: "contributing" },
-        },
-      ],
+      sidebar,
+      components: {
+        Head: "./src/components/Head.astro",
+        SocialIcons: "./src/components/SocialIcons.astro",
+      },
     }),
     d2({
       layout: "elk",
     }),
-    markdownPages(),
+    markdownPages({
+      sidebar,
+      siteTitle: "Chinmina",
+      siteDescription: "GitHub App token vending machine for Buildkite pipelines.",
+    }),
   ],
 })

--- a/package.json
+++ b/package.json
@@ -8,7 +8,16 @@
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "remark-directive": "^3.0.0",
+    "remark-mdx": "^3.1.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.5",
+    "vitest": "^3.0.0"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,25 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+    devDependencies:
+      remark-directive:
+        specifier: ^3.0.0
+        version: 3.0.1
+      remark-mdx:
+        specifier: ^3.1.0
+        version: 3.1.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-stringify:
+        specifier: ^11.0.0
+        version: 11.0.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(yaml@2.8.2)
 
 packages:
 
@@ -798,8 +817,14 @@ packages:
   '@terrastruct/d2@0.1.33':
     resolution: {integrity: sha512-eK5hyfGIJFolC7sUsiKvWdY9xGFctTe3d+PSijo09IYDso8psztC+A4SammizXtlwYZpnnW0AtDjfBYauceSeA==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -842,6 +867,35 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -926,6 +980,10 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -969,12 +1027,20 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -991,6 +1057,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -1084,6 +1154,10 @@ packages:
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -1207,6 +1281,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expressive-code@0.41.7:
     resolution: {integrity: sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA==}
@@ -1377,6 +1455,9 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -1407,6 +1488,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
@@ -1671,6 +1755,13 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -1839,6 +1930,9 @@ packages:
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -1862,11 +1956,17 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   starlight-heading-badges@0.6.1:
     resolution: {integrity: sha512-k89LlfxWSI136QOaedf70cZ29oDfv5xb6C2TIipt0RTk6TltVvUwFKk2H7gd+bVAjpH18CmzlGhCa5moEtyeZA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@astrojs/starlight': '>=0.32.0'
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
@@ -1890,6 +1990,9 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -1904,6 +2007,12 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -1911,6 +2020,18 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2068,6 +2189,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -2114,6 +2240,34 @@ packages:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0
     peerDependenciesMeta:
       vite:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   volar-service-css@0.0.68:
@@ -2214,6 +2368,11 @@ packages:
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   widest-line@5.0.0:
     resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
@@ -2930,9 +3089,16 @@ snapshots:
 
   '@terrastruct/d2@0.1.33': {}
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -2974,6 +3140,48 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@24.10.1)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@24.10.1)(yaml@2.8.2)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
@@ -3068,6 +3276,8 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -3213,9 +3423,19 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
+  cac@6.7.14: {}
+
   camelcase@8.0.0: {}
 
   ccount@2.0.1: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
 
   chalk@5.6.2: {}
 
@@ -3226,6 +3446,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -3304,6 +3526,8 @@ snapshots:
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
+
+  deep-eql@5.0.2: {}
 
   defu@6.1.4: {}
 
@@ -3476,6 +3700,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   eventemitter3@5.0.4: {}
+
+  expect-type@1.3.0: {}
 
   expressive-code@0.41.7:
     dependencies:
@@ -3757,6 +3983,8 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -3776,6 +4004,8 @@ snapshots:
   lodash@4.17.21: {}
 
   longest-streak@3.1.0: {}
+
+  loupe@3.2.1: {}
 
   lru-cache@11.2.6: {}
 
@@ -4341,6 +4571,10 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
@@ -4630,6 +4864,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   sisteransi@1.0.5: {}
 
   sitemap@8.0.3:
@@ -4647,6 +4883,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   starlight-heading-badges@0.6.1(@astrojs/starlight@0.37.6(astro@5.18.0(@types/node@24.10.1)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))):
     dependencies:
       '@astrojs/markdown-remark': 6.3.10
@@ -4656,6 +4894,8 @@ snapshots:
       unist-util-visit: 5.1.0
     transitivePeerDependencies:
       - supports-color
+
+  std-env@3.10.0: {}
 
   stream-replace-string@2.0.0: {}
 
@@ -4684,6 +4924,10 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -4704,12 +4948,22 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   trim-lines@3.0.1: {}
 
@@ -4831,6 +5085,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@24.10.1)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.1(@types/node@24.10.1)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@6.4.1(@types/node@24.10.1)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
@@ -4847,6 +5122,48 @@ snapshots:
   vitefu@1.1.2(vite@6.4.1(@types/node@24.10.1)(yaml@2.8.2)):
     optionalDependencies:
       vite: 6.4.1(@types/node@24.10.1)(yaml@2.8.2)
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@24.10.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.1(@types/node@24.10.1)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@24.10.1)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 24.10.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   volar-service-css@0.0.68(@volar/language-service@2.4.28):
     dependencies:
@@ -4948,6 +5265,11 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   which-pm-runs@1.1.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@5.0.0:
     dependencies:

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,11 +1,15 @@
 ---
 import Default from "@astrojs/starlight/components/Head.astro"
 
-const route = Astro.locals.starlightRoute
-const mdUrl =
-  route?.entry?.id != null && Astro.site
-    ? new URL(`/${route.entry.id}.md`, Astro.site).href
-    : null
+const entry = Astro.locals.starlightRoute?.entry
+let mdUrl: string | null = null
+if (entry != null && Astro.site) {
+  const isIndex = entry.filePath?.endsWith("/index.md") || entry.filePath?.endsWith("/index.mdx")
+  const mdPath = isIndex
+    ? (entry.id ? `/${entry.id}/index.md` : `/index.md`)
+    : `/${entry.id}.md`
+  mdUrl = new URL(mdPath, Astro.site).href
+}
 ---
 
 <Default {...Astro.props} />

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,0 +1,12 @@
+---
+import Default from "@astrojs/starlight/components/Head.astro"
+
+const route = Astro.locals.starlightRoute
+const mdUrl =
+  route?.entry?.id != null && Astro.site
+    ? new URL(`/${route.entry.id}.md`, Astro.site).href
+    : null
+---
+
+<Default {...Astro.props} />
+{mdUrl && <link rel="alternate" type="text/markdown" href={mdUrl} />}

--- a/src/components/SocialIcons.astro
+++ b/src/components/SocialIcons.astro
@@ -1,0 +1,35 @@
+---
+import Default from "@astrojs/starlight/components/SocialIcons.astro"
+import { Icon } from "@astrojs/starlight/components"
+
+const route = Astro.locals.starlightRoute
+const mdPath = route?.entry?.id != null ? `/${route.entry.id}.md` : null
+---
+
+<Default {...Astro.props} />
+{
+  mdPath && (
+    <a href={mdPath} class="sl-flex md-link" title="Markdown version for LLMs">
+      <Icon name="seti:markdown" size="1em" />
+      <span>MD</span>
+    </a>
+  )
+}
+
+<style>
+  @layer starlight.components {
+    .md-link {
+      align-items: center;
+      gap: 0.25em;
+      color: var(--sl-color-text-accent);
+      text-decoration: none;
+      font-size: var(--sl-text-sm);
+      font-weight: 600;
+      padding: 0.5em;
+      margin: -0.5em;
+    }
+    .md-link:hover {
+      opacity: 0.66;
+    }
+  }
+</style>

--- a/src/components/SocialIcons.astro
+++ b/src/components/SocialIcons.astro
@@ -2,8 +2,14 @@
 import Default from "@astrojs/starlight/components/SocialIcons.astro"
 import { Icon } from "@astrojs/starlight/components"
 
-const route = Astro.locals.starlightRoute
-const mdPath = route?.entry?.id != null ? `/${route.entry.id}.md` : null
+const entry = Astro.locals.starlightRoute?.entry
+let mdPath: string | null = null
+if (entry != null) {
+  const isIndex = entry.filePath?.endsWith("/index.md") || entry.filePath?.endsWith("/index.mdx")
+  mdPath = isIndex
+    ? (entry.id ? `/${entry.id}/index.md` : `/index.md`)
+    : `/${entry.id}.md`
+}
 ---
 
 <Default {...Astro.props} />

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,3 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+/// <reference path="../node_modules/@astrojs/starlight/virtual-internal.d.ts" />

--- a/src/integrations/markdown-pages.mjs
+++ b/src/integrations/markdown-pages.mjs
@@ -1,0 +1,70 @@
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs"
+import { resolve, dirname, join } from "node:path"
+import { glob } from "node:fs/promises"
+import { transformMarkdown } from "./transform.mjs"
+
+/**
+ * Astro integration that serves raw markdown at `.md` routes for LLM consumption.
+ *
+ * - Dev: Vite middleware intercepts `*.md` requests and returns transformed source
+ * - Build: writes transformed `.md` files alongside HTML output in `dist/`
+ */
+export default function markdownPages() {
+  return {
+    name: "markdown-pages",
+
+    hooks: {
+      "astro:server:setup": ({ server }) => {
+        server.middlewares.use(async (req, res, next) => {
+          const url = req.url ?? ""
+          if (!url.endsWith(".md")) return next()
+
+          // Map URL path to source file: strip leading `/` and `.md` suffix
+          const urlPath = url.replace(/\.md$/, "").replace(/^\//, "")
+          const srcBase = resolve("src/content/docs", urlPath)
+
+          let content, isMdx
+          try {
+            try {
+              content = readFileSync(srcBase + ".mdx", "utf8")
+              isMdx = true
+            } catch {
+              content = readFileSync(srcBase + ".md", "utf8")
+              isMdx = false
+            }
+          } catch {
+            return next()
+          }
+
+          const transformed = await transformMarkdown(content, { isMdx })
+          res.setHeader("Content-Type", "text/markdown; charset=utf-8")
+          res.end(transformed)
+        })
+      },
+
+      "astro:build:done": async ({ dir }) => {
+        const docsDir = resolve("src/content/docs")
+        const distDir = dir.pathname.replace(/\/$/, "")
+
+        const files = []
+        for await (const file of glob("**/*.{md,mdx}", { cwd: docsDir })) {
+          files.push(file)
+        }
+
+        for (const file of files) {
+          const srcPath = join(docsDir, file)
+          const isMdx = file.endsWith(".mdx")
+          const content = readFileSync(srcPath, "utf8")
+          const transformed = await transformMarkdown(content, { isMdx })
+
+          // Strip .mdx extension and use .md; keep .md as-is
+          const outRelative = isMdx ? file.replace(/\.mdx$/, ".md") : file
+          const outPath = join(distDir, outRelative)
+
+          mkdirSync(dirname(outPath), { recursive: true })
+          writeFileSync(outPath, transformed, "utf8")
+        }
+      },
+    },
+  }
+}

--- a/src/integrations/markdown-pages.mjs
+++ b/src/integrations/markdown-pages.mjs
@@ -73,7 +73,7 @@ async function generateLlmsTxt({ siteTitle, siteDescription, sidebar, siteUrl, d
       const dir = section.autogenerate.directory
       const found = []
       for await (const file of glob(`${dir}/**/*.{md,mdx}`, { cwd: docsDir })) {
-        found.push(file.replace(/\.(md|mdx)$/, ""))
+        found.push(file.replace(/\/index\.(md|mdx)$/, "").replace(/\.(md|mdx)$/, ""))
       }
       found.sort()
       slugs = found
@@ -83,7 +83,9 @@ async function generateLlmsTxt({ siteTitle, siteDescription, sidebar, siteUrl, d
       const meta = pageCache.get(slug)
       const title = meta?.title ?? slug
       const description = meta?.description
-      const url = `${siteUrl}/${slug}.md`
+      // Index pages live at [slug]/index.md, not [slug].md
+      const mdFile = meta?._isIndex ? `${slug}/index.md` : `${slug}.md`
+      const url = `${siteUrl}/${mdFile}`
       lines.push(description ? `- [${title}](${url}): ${description}` : `- [${title}](${url})`)
     }
     lines.push("")
@@ -163,8 +165,9 @@ export default function markdownPages({ sidebar, siteTitle, siteDescription } = 
           const frontmatterBlock = extractFrontmatterBlock(content)
           if (frontmatterBlock) {
             // Normalize slug: strip /index suffix so it matches sidebar entries
-            const slug = file.replace(/\/index\.(md|mdx)$/, "").replace(/\.(md|mdx)$/, "")
-            pageCache.set(slug, parseFrontmatterFields(frontmatterBlock))
+            const isIndex = /\/index\.(md|mdx)$/.test(file)
+            const slug = isIndex ? file.replace(/\/index\.(md|mdx)$/, "") : file.replace(/\.(md|mdx)$/, "")
+            pageCache.set(slug, { ...parseFrontmatterFields(frontmatterBlock), _isIndex: isIndex })
           }
 
           const transformed = await transformMarkdown(content, { isMdx })

--- a/src/integrations/markdown-pages.mjs
+++ b/src/integrations/markdown-pages.mjs
@@ -118,13 +118,17 @@ export default function markdownPages({ sidebar, siteTitle, siteDescription } = 
       },
 
       "astro:server:setup": ({ server }) => {
+        const devDocsDir = resolve("src/content/docs")
         server.middlewares.use(async (req, res, next) => {
           const url = req.url ?? ""
           if (!url.endsWith(".md")) return next()
 
           // Map URL path to source file: strip leading `/` and `.md` suffix
           const urlPath = url.replace(/\.md$/, "").replace(/^\//, "")
-          const srcBase = resolve("src/content/docs", urlPath)
+          const srcBase = resolve(devDocsDir, urlPath)
+
+          // Reject paths that escape the docs root
+          if (!srcBase.startsWith(devDocsDir + "/") && srcBase !== devDocsDir) return next()
 
           let content, isMdx
           try {
@@ -162,13 +166,12 @@ export default function markdownPages({ sidebar, siteTitle, siteDescription } = 
           const isMdx = file.endsWith(".mdx")
           const content = readFileSync(srcPath, "utf8")
 
+          // Normalize slug: strip /index suffix so it matches sidebar entries
+          const isIndex = /\/index\.(md|mdx)$/.test(file)
+          const slug = isIndex ? file.replace(/\/index\.(md|mdx)$/, "") : file.replace(/\.(md|mdx)$/, "")
           const frontmatterBlock = extractFrontmatterBlock(content)
-          if (frontmatterBlock) {
-            // Normalize slug: strip /index suffix so it matches sidebar entries
-            const isIndex = /\/index\.(md|mdx)$/.test(file)
-            const slug = isIndex ? file.replace(/\/index\.(md|mdx)$/, "") : file.replace(/\.(md|mdx)$/, "")
-            pageCache.set(slug, { ...parseFrontmatterFields(frontmatterBlock), _isIndex: isIndex })
-          }
+          const fields = frontmatterBlock ? parseFrontmatterFields(frontmatterBlock) : {}
+          pageCache.set(slug, { ...fields, _isIndex: isIndex })
 
           const transformed = await transformMarkdown(content, { isMdx })
           const outRelative = isMdx ? file.replace(/\.mdx$/, ".md") : file

--- a/src/integrations/markdown-pages.mjs
+++ b/src/integrations/markdown-pages.mjs
@@ -4,16 +4,117 @@ import { glob } from "node:fs/promises"
 import { transformMarkdown } from "./transform.mjs"
 
 /**
+ * Extract title and description from a raw frontmatter block.
+ * Only handles simple string values — sufficient for docs frontmatter.
+ */
+function parseFrontmatterFields(frontmatter) {
+  const result = {}
+  for (const line of frontmatter.split("\n")) {
+    const m = line.match(/^(title|description):\s*(.+)$/)
+    if (m) result[m[1]] = m[2].trim().replace(/^["']|["']$/g, "")
+  }
+  return result
+}
+
+/** Extract raw frontmatter block (including --- delimiters) from file content. */
+function extractFrontmatterBlock(content) {
+  if (!content.startsWith("---")) return null
+  const end = content.indexOf("\n---", 3)
+  if (end === -1) return null
+  return content.slice(0, end + 4)
+}
+
+/**
+ * Flatten a sidebar items array to an array of slug strings, recursing into groups.
+ * Does not handle `autogenerate` — callers must resolve those separately.
+ */
+function flattenSlugs(items) {
+  const slugs = []
+  for (const item of items) {
+    if (typeof item === "string") {
+      slugs.push(item)
+    } else if (item.link) {
+      slugs.push(item.link)
+    } else if (item.items) {
+      slugs.push(...flattenSlugs(item.items))
+    }
+    // autogenerate entries are skipped here; handled at the top-level section loop
+  }
+  return slugs
+}
+
+/**
+ * Generate llms.txt content from the sidebar config and page frontmatter cache.
+ *
+ * @param {object} opts
+ * @param {string} opts.siteTitle
+ * @param {string|undefined} opts.siteDescription
+ * @param {Array} opts.sidebar
+ * @param {string} opts.siteUrl  absolute site URL without trailing slash
+ * @param {string} opts.docsDir  absolute path to src/content/docs
+ * @param {Map<string, {title?: string, description?: string}>} pageCache  slug → metadata
+ */
+async function generateLlmsTxt({ siteTitle, siteDescription, sidebar, siteUrl, docsDir, pageCache }) {
+  const lines = []
+  lines.push(`# ${siteTitle}`, "")
+  if (siteDescription) {
+    lines.push(`> ${siteDescription}`, "")
+  }
+
+  for (const section of sidebar) {
+    lines.push(`## ${section.label}`, "")
+
+    let slugs = []
+    if (section.link) {
+      slugs = [section.link]
+    } else if (section.items) {
+      slugs = flattenSlugs(section.items)
+    } else if (section.autogenerate) {
+      const dir = section.autogenerate.directory
+      const found = []
+      for await (const file of glob(`${dir}/**/*.{md,mdx}`, { cwd: docsDir })) {
+        found.push(file.replace(/\.(md|mdx)$/, ""))
+      }
+      found.sort()
+      slugs = found
+    }
+
+    for (const slug of slugs) {
+      const meta = pageCache.get(slug)
+      const title = meta?.title ?? slug
+      const description = meta?.description
+      const url = `${siteUrl}/${slug}.md`
+      lines.push(description ? `- [${title}](${url}): ${description}` : `- [${title}](${url})`)
+    }
+    lines.push("")
+  }
+
+  return lines.join("\n")
+}
+
+/**
  * Astro integration that serves raw markdown at `.md` routes for LLM consumption.
  *
+ * Options:
+ * - `sidebar`         Starlight sidebar config array — used to generate llms.txt
+ * - `siteTitle`       Site title for the llms.txt header
+ * - `siteDescription` Optional one-line site description for llms.txt
+ *
  * - Dev: Vite middleware intercepts `*.md` requests and returns transformed source
- * - Build: writes transformed `.md` files alongside HTML output in `dist/`
+ * - Build: writes transformed `.md` files alongside HTML output in `dist/`,
+ *          and generates `llms.txt` at the root if sidebar config is provided
  */
-export default function markdownPages() {
+export default function markdownPages({ sidebar, siteTitle, siteDescription } = {}) {
+  let siteUrl = ""
+
   return {
     name: "markdown-pages",
 
     hooks: {
+      "astro:config:done": ({ config }) => {
+        siteUrl = config.site?.replace(/\/$/, "") ?? ""
+      },
+
       "astro:server:setup": ({ server }) => {
         server.middlewares.use(async (req, res, next) => {
           const url = req.url ?? ""
@@ -51,18 +152,39 @@ export default function markdownPages() {
           files.push(file)
         }
 
+        // Build frontmatter cache while generating .md files
+        const pageCache = new Map()
+
         for (const file of files) {
           const srcPath = join(docsDir, file)
           const isMdx = file.endsWith(".mdx")
           const content = readFileSync(srcPath, "utf8")
-          const transformed = await transformMarkdown(content, { isMdx })
 
-          // Strip .mdx extension and use .md; keep .md as-is
+          const frontmatterBlock = extractFrontmatterBlock(content)
+          if (frontmatterBlock) {
+            // Normalize slug: strip /index suffix so it matches sidebar entries
+            const slug = file.replace(/\/index\.(md|mdx)$/, "").replace(/\.(md|mdx)$/, "")
+            pageCache.set(slug, parseFrontmatterFields(frontmatterBlock))
+          }
+
+          const transformed = await transformMarkdown(content, { isMdx })
           const outRelative = isMdx ? file.replace(/\.mdx$/, ".md") : file
           const outPath = join(distDir, outRelative)
 
           mkdirSync(dirname(outPath), { recursive: true })
           writeFileSync(outPath, transformed, "utf8")
+        }
+
+        if (sidebar && siteTitle) {
+          const llmsTxt = await generateLlmsTxt({
+            siteTitle,
+            siteDescription,
+            sidebar,
+            siteUrl,
+            docsDir,
+            pageCache,
+          })
+          writeFileSync(join(distDir, "llms.txt"), llmsTxt, "utf8")
         }
       },
     },

--- a/src/integrations/transform.mjs
+++ b/src/integrations/transform.mjs
@@ -6,7 +6,7 @@ import remarkStringify from "remark-stringify"
 
 /**
  * Walk all nodes in a unist tree, calling visitor(node, index, parent) for each.
- * The visitor may mutate parent.children; return false to skip node's children.
+ * Return false from visitor to skip node's children.
  */
 function walk(tree, visitor) {
   function traverse(node, index, parent) {
@@ -15,8 +15,6 @@ function walk(tree, visitor) {
     if (node.children) {
       for (let i = 0; i < node.children.length; i++) {
         traverse(node.children[i], i, node)
-        // Re-check index in case children were spliced
-        if (node.children[i] !== undefined && node.children[i] !== node.children[i]) i--
       }
     }
   }

--- a/src/integrations/transform.mjs
+++ b/src/integrations/transform.mjs
@@ -1,0 +1,194 @@
+import { unified } from "unified"
+import remarkParse from "remark-parse"
+import remarkMdx from "remark-mdx"
+import remarkDirective from "remark-directive"
+import remarkStringify from "remark-stringify"
+
+/**
+ * Walk all nodes in a unist tree, calling visitor(node, index, parent) for each.
+ * The visitor may mutate parent.children; return false to skip node's children.
+ */
+function walk(tree, visitor) {
+  function traverse(node, index, parent) {
+    const result = visitor(node, index, parent)
+    if (result === false) return
+    if (node.children) {
+      for (let i = 0; i < node.children.length; i++) {
+        traverse(node.children[i], i, node)
+        // Re-check index in case children were spliced
+        if (node.children[i] !== undefined && node.children[i] !== node.children[i]) i--
+      }
+    }
+  }
+  traverse(tree, null, null)
+}
+
+/**
+ * Remark plugin: rewrite internal links to append `.md` before any `#` fragment.
+ * Leaves external (http/https) and anchor-only (#) links unchanged.
+ */
+function remarkRewriteLinks() {
+  return (tree) => {
+    walk(tree, (node) => {
+      if (node.type !== "link") return
+      const url = node.url
+      if (!url) return
+      if (url.startsWith("http://") || url.startsWith("https://") || url.startsWith("#")) return
+
+      const hashIndex = url.indexOf("#")
+      if (hashIndex === -1) {
+        node.url = url + ".md"
+      } else {
+        node.url = url.slice(0, hashIndex) + ".md" + url.slice(hashIndex)
+      }
+    })
+  }
+}
+
+const DIRECTIVE_TYPE_LABEL = { note: "NOTE", tip: "TIP", caution: "CAUTION", danger: "WARNING" }
+
+/**
+ * Remark plugin: convert :::note/tip/caution/danger container directives
+ * to GitHub-flavoured blockquote admonitions.
+ */
+function remarkDirectivesToBlockquotes() {
+  return (tree) => {
+    function convert(nodes) {
+      for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i]
+        if (node.type === "containerDirective" && DIRECTIVE_TYPE_LABEL[node.name]) {
+          const label = DIRECTIVE_TYPE_LABEL[node.name]
+          nodes[i] = {
+            type: "blockquote",
+            children: [
+              { type: "paragraph", children: [{ type: "text", value: `[!${label}]` }] },
+              ...(node.children ?? []),
+            ],
+          }
+        } else if (node.children) {
+          convert(node.children)
+        }
+      }
+    }
+    convert(tree.children)
+  }
+}
+
+/**
+ * Known component translations: instead of generic child-unwrapping, these
+ * components produce specific remark nodes for meaningful LLM output.
+ *
+ * Each function receives the MDX JSX node and returns an array of remark nodes.
+ */
+const COMPONENT_TRANSLATIONS = {
+  /** Inline placeholder marker: <Later name="X" /> → `📝 X` */
+  Later(node) {
+    const nameAttr = node.attributes?.find((a) => a.name === "name")
+    const name = nameAttr?.value ?? ""
+    return [{ type: "inlineCode", value: `📝 ${name}` }]
+  },
+
+  /** Config reference: <ConfigRef name="X" /> → [`X`](../reference/configuration#x) */
+  ConfigRef(node) {
+    const nameAttr = node.attributes?.find((a) => a.name === "name")
+    const name = nameAttr?.value ?? ""
+    return [
+      {
+        type: "link",
+        url: `../reference/configuration#${name.toLowerCase()}`,
+        children: [{ type: "inlineCode", value: name }],
+      },
+    ]
+  },
+
+  /** Callout box: <Aside type="tip"> → GitHub-flavoured blockquote admonition */
+  Aside(node) {
+    const typeAttr = node.attributes?.find((a) => a.name === "type")
+    const type = typeAttr?.value ?? "note"
+    const TYPE_LABEL = { note: "NOTE", tip: "TIP", caution: "CAUTION", danger: "WARNING" }
+    const label = TYPE_LABEL[type] ?? "NOTE"
+    return [
+      {
+        type: "blockquote",
+        children: [
+          { type: "paragraph", children: [{ type: "text", value: `[!${label}]` }] },
+          ...(node.children ?? []),
+        ],
+      },
+    ]
+  },
+}
+
+/**
+ * Remark plugin: strip MDX-specific nodes and unwrap PascalCase components.
+ * - Removes `mdxjsEsm` nodes (import/export statements)
+ * - Removes `mdxFlowExpression`/`mdxTextExpression` nodes (MDX expression blocks)
+ * - For known PascalCase components, applies a translation from COMPONENT_TRANSLATIONS
+ * - For unknown PascalCase components, replaces node with its children
+ * - Lowercase HTML tags are left unchanged
+ */
+function remarkStripMdx() {
+  return (tree) => {
+    const STRIP_TYPES = new Set(["mdxjsEsm", "mdxFlowExpression", "mdxTextExpression"])
+
+    function unwrap(nodes) {
+      for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i]
+        if (STRIP_TYPES.has(node.type)) {
+          nodes.splice(i, 1)
+          i--
+        } else if (
+          (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") &&
+          node.name &&
+          /^[A-Z]/.test(node.name)
+        ) {
+          const translator = COMPONENT_TRANSLATIONS[node.name]
+          const replacement = translator ? translator(node) : (node.children ?? [])
+          nodes.splice(i, 1, ...replacement)
+          i-- // re-examine from same index; recurse into replacement children
+        } else if (node.children) {
+          unwrap(node.children)
+        }
+      }
+    }
+    unwrap(tree.children)
+  }
+}
+
+/**
+ * Extract YAML frontmatter from the top of a file.
+ * Returns { frontmatter, body } where frontmatter includes the delimiters,
+ * or { frontmatter: null, body: content } if none found.
+ */
+function extractFrontmatter(content) {
+  if (!content.startsWith("---")) return { frontmatter: null, body: content }
+  const end = content.indexOf("\n---", 3)
+  if (end === -1) return { frontmatter: null, body: content }
+  const frontmatter = content.slice(0, end + 4) // include closing ---
+  const body = content.slice(end + 4)
+  return { frontmatter, body }
+}
+
+/**
+ * Transform markdown/MDX source content for LLM consumption.
+ *
+ * @param {string} content - Raw file content
+ * @param {{ isMdx?: boolean }} options
+ * @returns {Promise<string>} Transformed markdown
+ */
+export async function transformMarkdown(content, { isMdx = false } = {}) {
+  const { frontmatter, body } = extractFrontmatter(content)
+
+  const processor = unified().use(remarkParse).use(remarkDirective).use(remarkDirectivesToBlockquotes)
+
+  if (isMdx) {
+    processor.use(remarkMdx).use(remarkStripMdx)
+  }
+
+  processor.use(remarkRewriteLinks).use(remarkStringify)
+
+  const result = await processor.process(body)
+  const transformed = String(result)
+
+  return frontmatter ? frontmatter + "\n" + transformed : transformed
+}

--- a/src/integrations/transform.test.mjs
+++ b/src/integrations/transform.test.mjs
@@ -1,0 +1,323 @@
+import { describe, it, expect } from "vitest"
+import { transformMarkdown } from "./transform.mjs"
+
+describe("transformMarkdown — .md files", () => {
+  it("preserves frontmatter", async () => {
+    const input = `---
+title: Guide
+description: A test guide.
+---
+
+# Guide
+
+Content here.
+`
+    expect(await transformMarkdown(input)).toMatchInlineSnapshot(`
+      "---
+      title: Guide
+      description: A test guide.
+      ---
+      # Guide
+
+      Content here.
+      "
+    `)
+  })
+
+  it("rewrites internal relative links", async () => {
+    const input = `# Guide
+
+See the [getting started](../guides/getting-started) page.
+`
+    expect(await transformMarkdown(input)).toMatchInlineSnapshot(`
+      "# Guide
+
+      See the [getting started](../guides/getting-started.md) page.
+      "
+    `)
+  })
+
+  it("rewrites internal absolute-path links", async () => {
+    const input = `# Guide
+
+See [configuration](/reference/configuration).
+`
+    expect(await transformMarkdown(input)).toMatchInlineSnapshot(`
+      "# Guide
+
+      See [configuration](/reference/configuration.md).
+      "
+    `)
+  })
+
+  it("inserts .md before # fragment", async () => {
+    const input = `# Guide
+
+See [the section](../guides/getting-started#installation).
+`
+    expect(await transformMarkdown(input)).toMatchInlineSnapshot(`
+      "# Guide
+
+      See [the section](../guides/getting-started.md#installation).
+      "
+    `)
+  })
+
+  it("leaves external https:// links unchanged", async () => {
+    const input = `# Guide
+
+See [GitHub](https://github.com/chinmina/chinmina-bridge).
+`
+    expect(await transformMarkdown(input)).toMatchInlineSnapshot(`
+      "# Guide
+
+      See [GitHub](https://github.com/chinmina/chinmina-bridge).
+      "
+    `)
+  })
+
+  it("leaves anchor-only #section links unchanged", async () => {
+    const input = `# Guide
+
+Jump to [installation](#installation).
+`
+    expect(await transformMarkdown(input)).toMatchInlineSnapshot(`
+      "# Guide
+
+      Jump to [installation](#installation).
+      "
+    `)
+  })
+})
+
+describe("transformMarkdown — ::: directives", () => {
+  it("converts :::caution to [!CAUTION] blockquote", async () => {
+    const input = `# Page
+
+:::caution
+
+**Git tags are not static:** they can be updated to point to a different
+commit SHA. Examine the recorded claims for the exact commit.
+
+There are claims recorded for the exact commit of both the workflow that
+produced the artifact and the commit that the artifact source was built from.
+
+:::
+`
+    expect(await transformMarkdown(input)).toMatchInlineSnapshot(`
+      "# Page
+
+      > \\[!CAUTION]
+      >
+      > **Git tags are not static:** they can be updated to point to a different
+      > commit SHA. Examine the recorded claims for the exact commit.
+      >
+      > There are claims recorded for the exact commit of both the workflow that
+      > produced the artifact and the commit that the artifact source was built from.
+      "
+    `)
+  })
+
+  it("converts :::note to [!NOTE] blockquote", async () => {
+    const input = `# Page
+
+:::note
+A simple note.
+:::
+`
+    expect(await transformMarkdown(input)).toMatchInlineSnapshot(`
+      "# Page
+
+      > \\[!NOTE]
+      >
+      > A simple note.
+      "
+    `)
+  })
+
+  it("converts :::tip to [!TIP] blockquote", async () => {
+    const input = `# Page
+
+:::tip
+A helpful tip.
+:::
+`
+    expect(await transformMarkdown(input)).toMatchInlineSnapshot(`
+      "# Page
+
+      > \\[!TIP]
+      >
+      > A helpful tip.
+      "
+    `)
+  })
+})
+
+describe("transformMarkdown — .mdx files", () => {
+  it("strips import statements", async () => {
+    const input = `import { Card } from "@astrojs/starlight/components"
+
+# Page
+
+Content here.
+`
+    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+      "# Page
+
+      Content here.
+      "
+    `)
+  })
+
+  it("strips export statements", async () => {
+    const input = `export const title = "Hello"
+
+# Page
+
+Content here.
+`
+    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+      "# Page
+
+      Content here.
+      "
+    `)
+  })
+
+  it("renders <Aside type=\"note\"> as GitHub blockquote admonition", async () => {
+    const input = `# Page
+
+<Aside type="note">
+This is important.
+</Aside>
+`
+    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+      "# Page
+
+      > \\[!NOTE]
+      >
+      > This is important.
+      "
+    `)
+  })
+
+  it("renders <Aside type=\"tip\"> as [!TIP] blockquote", async () => {
+    const input = `# Page
+
+<Aside type="tip">
+A helpful tip.
+</Aside>
+`
+    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+      "# Page
+
+      > \\[!TIP]
+      >
+      > A helpful tip.
+      "
+    `)
+  })
+
+  it("renders <Aside type=\"caution\"> as [!CAUTION] blockquote", async () => {
+    const input = `# Page
+
+<Aside type="caution">
+Be careful here.
+</Aside>
+`
+    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+      "# Page
+
+      > \\[!CAUTION]
+      >
+      > Be careful here.
+      "
+    `)
+  })
+
+  it("renders <ConfigRef name=\"X\" /> as a linked inline code reference", async () => {
+    const input = `# Page
+
+Set <ConfigRef name="JWT_BUILDKITE_ORGANIZATION_SLUG" /> to your org slug.
+`
+    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+      "# Page
+
+      Set [\`JWT_BUILDKITE_ORGANIZATION_SLUG\`](../reference/configuration.md#jwt_buildkite_organization_slug) to your org slug.
+      "
+    `)
+  })
+
+  it("renders inline <Later name=\"X\" /> as backtick placeholder", async () => {
+    const input = `# Page
+
+Save the token as <Later name="BUILDKITE_API_TOKEN" />.
+`
+    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+      "# Page
+
+      Save the token as \`📝 BUILDKITE_API_TOKEN\`.
+      "
+    `)
+  })
+
+  it("unwraps unknown PascalCase component, keeping children as prose", async () => {
+    const input = `# Page
+
+<Card title="Example">
+Some content.
+</Card>
+`
+    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+      "# Page
+
+      Some content.
+      "
+    `)
+  })
+
+  it("strips MDX expression blocks (e.g. {/* comment */})", async () => {
+    const input = `# Page
+
+{/* This is a comment */}
+
+Content here.
+`
+    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+      "# Page
+
+      Content here.
+      "
+    `)
+  })
+
+  it("leaves lowercase HTML tags unchanged", async () => {
+    const input = `# Page
+
+Some text with <em>emphasis</em> and a line break.<br />
+`
+    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+      "# Page
+
+      Some text with <em>emphasis</em> and a line break.<br />
+      "
+    `)
+  })
+
+  it("applies both MDX stripping and link rewriting", async () => {
+    const input = `import { Card } from "@astrojs/starlight/components"
+
+# Page
+
+<Card title="Example">
+See [getting started](../guides/getting-started#setup).
+</Card>
+`
+    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+      "# Page
+
+      See [getting started](../guides/getting-started.md#setup).
+      "
+    `)
+  })
+})


### PR DESCRIPTION
## Purpose

LLMs and AI tools that browse the web receive rendered HTML rather than the source content, which is verbose and strips semantic structure. This adds a parallel set of raw markdown files so that tools can fetch clean, structured content directly.

The feature covers three layers of discoverability:

1. A build-time integration generates transformed `.md` files in `dist/` (and serves them in dev via middleware), with a remark pipeline that strips MDX boilerplate, translates Starlight-specific components into readable equivalents (callouts → GitHub blockquotes, `<ConfigRef>` → linked inline code), and rewrites internal links to also point at `.md` files.

2. A `<link rel="alternate" type="text/markdown">` in each page's `<head>` makes the markdown counterpart machine-discoverable from the HTML.

3. A header link button (markdown icon + "MD" text) gives human visitors a direct path to the raw source, and a generated `llms.txt` at the site root provides a structured index following the llmstxt.org spec — organized by sidebar section, linking to `.md` URLs with page descriptions.

## Context

- Follows the llmstxt.org specification for the site index format
- Component overrides import directly from `@astrojs/starlight/components/` rather than via `virtual:starlight/components/` to avoid a circular module reference that causes a heap OOM during static site generation
- Index pages (e.g. `contributing/index.md`) require path-aware link generation since Starlight normalizes their `entry.id` by stripping the `/index` suffix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docs now include an “alternate” link and an “MD” quick‑link to view source markdown.
  * Build now emits plain‑Markdown artifacts and generates a site index of markdown pages for offline/AI use.
  * Dev server serves transformed Markdown endpoints for previewing source files.

* **Chores**
  * Improved Markdown processing: preserves frontmatter, converts container notes to admonitions, and normalizes internal links.
  * Added a test script and tooling to validate markdown transformations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->