### PR TITLE
build: add Biome for formatting and linting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is an Astro Starlight documentation repository that uses PNPM to run JS tas
 - `pnpm run build`: check and build the site to `dist/`
 - `pnpm run dev`: runs a local dev server that can be accessed via a browser
 
-Run `pnpm run build` before committing or pushing any changes.
+Run `pnpm run agent` before committing or pushing any changes. This formats, lint-fixes, and builds in one step.
 
 ## Writing documentation
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,9 +1,9 @@
 // @ts-check
-import { defineConfig } from "astro/config"
-import starlight from "@astrojs/starlight"
-import starlightHeadingBadges from "starlight-heading-badges"
 
+import starlight from "@astrojs/starlight"
+import { defineConfig } from "astro/config"
 import d2 from "astro-d2"
+import starlightHeadingBadges from "starlight-heading-badges"
 import markdownPages from "./src/integrations/markdown-pages.mjs"
 
 const sidebar = [

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -95,7 +95,8 @@ export default defineConfig({
     markdownPages({
       sidebar,
       siteTitle: "Chinmina",
-      siteDescription: "GitHub App token vending machine for Buildkite pipelines.",
+      siteDescription:
+        "GitHub App token vending machine for Buildkite pipelines.",
     }),
   ],
 })

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "lineWidth": 80
+  },
+  "javascript": {
+    "formatter": {
+      "semicolons": "asNeeded",
+      "quoteStyle": "double"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "useBlockStatements": "error"
+      }
+    }
+  },
+  "files": {
+    "includes": ["**", "!.astro", "!.claude", "!.github", "!.vscode", "!dist"]
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.astro"],
+      "linter": {
+        "enabled": false
+      },
+      "formatter": {
+        "enabled": false
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,23 +1,19 @@
 {
   "name": "docs",
-  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",
-  "type": "module",
   "version": "0.0.1",
+  "type": "module",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "test": "vitest run"
-  },
-  "devDependencies": {
-    "remark-directive": "^3.0.0",
-    "remark-mdx": "^3.1.0",
-    "remark-parse": "^11.0.0",
-    "remark-stringify": "^11.0.0",
-    "unified": "^11.0.5",
-    "vitest": "^3.0.0"
+    "agent": "biome check --write --unsafe && vitest run && pnpm run build",
+    "test": "vitest run",
+    "lint": "biome lint",
+    "lint:fix": "biome lint --write --unsafe",
+    "fmt": "biome format --write",
+    "fmt:check": "biome format"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.6",
@@ -27,5 +23,15 @@
     "sharp": "^0.34.5",
     "starlight-heading-badges": "^0.6.1",
     "typescript": "^5.9.3"
-  }
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.8",
+    "remark-directive": "^3.0.0",
+    "remark-mdx": "^3.1.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.5",
+    "vitest": "^3.0.0"
+  },
+  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.8
+        version: 2.4.8
       remark-directive:
         specifier: ^3.0.0
         version: 3.0.1
@@ -123,6 +126,59 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@2.4.8':
+    resolution: {integrity: sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.8':
+    resolution: {integrity: sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.8':
+    resolution: {integrity: sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.8':
+    resolution: {integrity: sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@2.4.8':
+    resolution: {integrity: sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.4.8':
+    resolution: {integrity: sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.4.8':
+    resolution: {integrity: sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@2.4.8':
+    resolution: {integrity: sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.8':
+    resolution: {integrity: sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
@@ -2605,6 +2661,41 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@biomejs/biome@2.4.8':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.8
+      '@biomejs/cli-darwin-x64': 2.4.8
+      '@biomejs/cli-linux-arm64': 2.4.8
+      '@biomejs/cli-linux-arm64-musl': 2.4.8
+      '@biomejs/cli-linux-x64': 2.4.8
+      '@biomejs/cli-linux-x64-musl': 2.4.8
+      '@biomejs/cli-win32-arm64': 2.4.8
+      '@biomejs/cli-win32-x64': 2.4.8
+
+  '@biomejs/cli-darwin-arm64@2.4.8':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.8':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.8':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.8':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.8':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.8':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.8':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.8':
+    optional: true
 
   '@capsizecss/unpack@4.0.0':
     dependencies:

--- a/src/components/SocialIcons.astro
+++ b/src/components/SocialIcons.astro
@@ -1,6 +1,6 @@
 ---
-import Default from "@astrojs/starlight/components/SocialIcons.astro"
 import { Icon } from "@astrojs/starlight/components"
+import Default from "@astrojs/starlight/components/SocialIcons.astro"
 
 const entry = Astro.locals.starlightRoute?.entry
 let mdPath: string | null = null

--- a/src/content/docs/contributing/index.mdx
+++ b/src/content/docs/contributing/index.mdx
@@ -54,6 +54,7 @@ meet the same standards.
 
 It's better to submit multiple smaller, focused PRs than one large PR covering
 many concerns.
+
 </Aside>
 
 ## AI-Generated Contributions
@@ -81,6 +82,7 @@ manually written and AI-generated code.
 
 If you're uncertain about the origin of generated code, please investigate
 before submitting.
+
 </Aside>
 
 [crush-agent]: https://github.com/charmbracelet/crush

--- a/src/content/docs/guides/buildkite-integration.mdx
+++ b/src/content/docs/guides/buildkite-integration.mdx
@@ -9,13 +9,13 @@ There are two broad ways that Chinmina Bridge can be integrated with
 Buildkite pipelines:
 
 1. **Git authentication**: This allows Buildkite pipelines to authenticate with
-  GitHub using a token that is scoped to the pipeline, and can be used to
-  access private repositories.
+   GitHub using a token that is scoped to the pipeline, and can be used to
+   access private repositories.
 
 2. **Token generation**: This allows Buildkite pipelines to generate a GitHub
-  token that can be used to access private repositories, such as downloading
-  private release assets. Tokens can be exported automatically as environment
-  variables or retrieved programmatically via a helper script.
+   token that can be used to access private repositories, such as downloading
+   private release assets. Tokens can be exported automatically as environment
+   variables or retrieved programmatically via a helper script.
 
 Git authentication integration removes the need to configure SSH deploy keys for
 each repository, and token generation is a replacement for long-lived GitHub
@@ -31,7 +31,7 @@ Each use case is integrated using a Buildkite plugin:
 
 :::caution[Recommended setup]
 
-The plugins *can* be configured in individual pipeline steps, but production
+The plugins _can_ be configured in individual pipeline steps, but production
 installations should load the plugins in the Buildkite agent `bootstrap` and
 `environment` hooks.
 
@@ -47,8 +47,9 @@ particular.
 ## Configuration
 
 Full documentation for each plugin:
-  - [Chinmina Git Credentials][credentials-plugin]
-  - [Chinmina Token][chinmina-token]
+
+- [Chinmina Git Credentials][credentials-plugin]
+- [Chinmina Token][chinmina-token]
 
 Collect the following information from your Chinmina Bridge instance:
 
@@ -62,6 +63,7 @@ Collect the following information from your Chinmina Bridge instance:
 Both plugins support `CHINMINA_DEFAULT_URL` and `CHINMINA_DEFAULT_AUDIENCE` environment variables. Set these at the agent level to provide defaults for all pipelines, eliminating repetitive configuration.
 
 Configuration precedence (highest to lowest):
+
 1. Plugin parameters in pipeline configuration
 2. `CHINMINA_DEFAULT_*` environment variables
 3. Built-in defaults (audience only)
@@ -124,7 +126,7 @@ steps:
       # Using default URL and audience from agent environment
       - chinmina/chinmina-token#v1.4.0:
           environment:
-            - GITHUB_TOKEN=pipeline:release        # pipeline profile
+            - GITHUB_TOKEN=pipeline:release # pipeline profile
             - GITHUB_NPM_TOKEN=org:npm-packages # organization profile
 ```
 
@@ -168,13 +170,13 @@ gh release download --repo "${repo}" \
 
 #### When to use each approach
 
-| Use Case | Recommended Approach |
-|----------|---------------------|
-| Static token needs known upfront | `environment` array (declarative) |
-| Multiple tokens for different services | `environment` array |
-| Dynamic profile selection | `chinmina_token` script |
-| Conditional token logic | `chinmina_token` script |
-| Token needed only in specific conditions | `chinmina_token` script |
+| Use Case                                 | Recommended Approach              |
+| ---------------------------------------- | --------------------------------- |
+| Static token needs known upfront         | `environment` array (declarative) |
+| Multiple tokens for different services   | `environment` array               |
+| Dynamic profile selection                | `chinmina_token` script           |
+| Conditional token logic                  | `chinmina_token` script           |
+| Token needed only in specific conditions | `chinmina_token` script           |
 
 ## Using Git credentials for authentication
 
@@ -235,6 +237,7 @@ When using `exclusive: true`, ensure the specified profile (or default profile i
 :::
 
 Use `exclusive: true` when:
+
 - System-level credential helpers interfere with pipeline-specific authentication
 - You need to ensure only Chinmina-vended tokens are used for GitHub operations
 - Operating in shared CI environments where credential helper precedence is unclear

--- a/src/content/docs/guides/customizing-permissions.mdx
+++ b/src/content/docs/guides/customizing-permissions.mdx
@@ -12,6 +12,7 @@ By default, Chinmina Bridge vends GitHub tokens with `contents:read` and `metada
 ### Elevated permissions for your repository
 
 Use pipeline profiles when your pipeline needs to:
+
 - Write comments on pull requests during automated code review
 - Publish releases directly from the pipeline
 - Manage deployment status
@@ -21,6 +22,7 @@ Pipeline profiles grant additional permissions while keeping access scoped to th
 ### Access to other repositories
 
 Use organization profiles when your pipeline needs to access repositories beyond its own:
+
 - Publishing to organization-wide Homebrew taps or package registries
 - Loading Buildkite plugins from private repositories
 - Reading shared configuration or tooling repositories
@@ -101,6 +103,7 @@ steps:
 ```
 
 Profile prefixes:
+
 - `pipeline:profile-name` → pipeline profile
 - `org:profile-name` → organization profile
 
@@ -136,7 +139,8 @@ steps:
 ```
 
 <Aside type="note">
-Git credentials plugin support for profiles requires plugin version 1.1.0 or later.
+  Git credentials plugin support for profiles requires plugin version 1.1.0 or
+  later.
 </Aside>
 
 ## Restricting profile access
@@ -160,6 +164,7 @@ Pipelines on other branches will receive a 403 error when requesting this profil
 ## Next steps
 
 See the [profile reference](../reference/profiles) for:
+
 - Complete field definitions
 - Match rule syntax and patterns
 - Available claims for authorization

--- a/src/content/docs/guides/distributed-cache.mdx
+++ b/src/content/docs/guides/distributed-cache.mdx
@@ -37,6 +37,7 @@ Collect these values as you proceed through the infrastructure setup sections. T
 
    Save the cache endpoint as <Later name="VALKEY_ADDRESS" /> and cache name
    (replication group ID or serverless cache name) as
+
    <Later name="VALKEY_IAM_CACHE_NAME" />.
 
 2. Enable in-transit encryption (TLS) on the cache. TLS is required for IAM

--- a/src/content/docs/guides/getting-started.mdx
+++ b/src/content/docs/guides/getting-started.mdx
@@ -7,7 +7,7 @@ import { Aside, Badge, Steps } from "@astrojs/starlight/components"
 
 {/* Shorthand component for a badge that indicates a value to be collected. */}
 export function Later({ name }) {
-  return <Badge text={`📝 ${name}`} variant="tip" />;
+return <Badge text={`📝 ${name}`} variant="tip" />;
 }
 
 Chinmina itself is a simple service, but it sits in the middle of an ecosystem.
@@ -139,7 +139,8 @@ configuration.
     and provide the ARN of the key here. This will allow Chinmina to sign tokens
     but protects the key from extraction and misuse.
 
-  - <ConfigRef name="GITHUB_APP_PRIVATE_KEY" /> **Use only if KMS is not available.**
+  - <ConfigRef name="GITHUB_APP_PRIVATE_KEY" /> **Use only if KMS is not
+    available.**
 
     The PEM formatted private key of the created GitHub app. **Store securely and
     provide to the container securely.** This is a highly sensitive credential.

--- a/src/content/docs/guides/observability.md
+++ b/src/content/docs/guides/observability.md
@@ -12,6 +12,7 @@ For audit log details, see the [auditing reference](../reference/auditing). For 
 Set `OBSERVE_ENABLED=true` to enable telemetry collection.
 
 Choose an exporter type with `OBSERVE_TYPE`:
+
 - `"grpc"` (default): Send to an OpenTelemetry collector via gRPC (port 4317)
 - `"http"`: Send via HTTP/protobuf OTLP (port 4318). Use this in environments where gRPC is blocked by HTTP proxies or load balancers.
 - `"stdout"`: Write to standard output (development only)
@@ -54,6 +55,7 @@ Generates a GitHub token for the pipeline's repository. This is the primary oper
 **Endpoint:** `POST /token`
 
 **Trace structure:**
+
 ```text
 Server span: POST /token
 ├── Client span: GET api.buildkite.com/v2/.../pipelines/...
@@ -63,20 +65,21 @@ Server span: POST /token
 The server span captures total request duration and HTTP status. The Buildkite API span shows pipeline lookup performance, and the GitHub API span shows token creation performance.
 
 **SLIs to monitor:**
+
 - p95/p99 server span duration
 - HTTP 5xx error rate
 - Cache hit rate (cached requests skip both API calls)
 
 **Suggested SLO targets:**
 
-| Metric | Objective | Rationale |
-|--------|-----------|-----------|
-| Success rate | 99.9% | Critical path for pipeline execution |
-| p99 latency | < 2s | Minimize delay in clone operations |
-| p95 latency | < 1s | Typical case performance |
-| Cache hit rate | > 70% | Reduce API load and latency |
-| GitHub API p95 latency | < 500ms | Monitor external dependency health |
-| Buildkite API p95 latency | < 300ms | Monitor external dependency health |
+| Metric                    | Objective | Rationale                            |
+| ------------------------- | --------- | ------------------------------------ |
+| Success rate              | 99.9%     | Critical path for pipeline execution |
+| p99 latency               | < 2s      | Minimize delay in clone operations   |
+| p95 latency               | < 1s      | Typical case performance             |
+| Cache hit rate            | > 70%     | Reduce API load and latency          |
+| GitHub API p95 latency    | < 500ms   | Monitor external dependency health   |
+| Buildkite API p95 latency | < 300ms   | Monitor external dependency health   |
 
 ### Git credentials
 
@@ -91,6 +94,7 @@ Identical trace structure to token generation (same underlying implementation). 
 Generates tokens scoped to repositories defined in an organization profile rather than the pipeline's own repository.
 
 **Trace structure:**
+
 ```text
 Server span: POST /organization/token/{profile}
 └── Client span: POST api.github.com/app/installations/.../access_tokens
@@ -100,26 +104,29 @@ No Buildkite API call occurs because the repository is determined by the profile
 
 **Suggested SLO targets:** Same as token endpoints. External API targets differ — only GitHub API applies:
 
-| Metric | Objective | Rationale |
-|--------|-----------|-----------|
-| GitHub API p95 latency | < 500ms | Monitor external dependency health |
+| Metric                 | Objective | Rationale                          |
+| ---------------------- | --------- | ---------------------------------- |
+| GitHub API p95 latency | < 500ms   | Monitor external dependency health |
 
 ### Background profile refresh
 
 Periodically fetches organization profile configurations from the configuration source.
 
 **Trace structure:**
+
 ```text
 Internal span: refresh_organization_profile
 └── Client span: GET api.github.com/...
 ```
 
 **Attributes:**
+
 - `profile.digest_current`: Previous configuration hash
 - `profile.digest_updated`: New configuration hash
 - `profile.digest_changed`: Whether content changed
 
 **SLIs to monitor:**
+
 - Span error rate (fetch failures affect profile availability)
 - `profile.digest_changed` frequency (unexpected changes may indicate configuration issues)
 
@@ -130,12 +137,14 @@ Internal span: refresh_organization_profile
 **Symptoms:** p95/p99 latency exceeds objectives
 
 **Investigation:**
+
 1. Check external API span durations
 2. Verify cache hit rate meets objectives
 3. Review connection timing attributes
 4. Check for network issues between service and APIs
 
 **Remediation:**
+
 - Increase token TTL to improve cache hit rate
 - Review network path to external APIs
 - Consider connection pooling configuration
@@ -145,12 +154,14 @@ Internal span: refresh_organization_profile
 **Symptoms:** HTTP 5xx error rate above threshold
 
 **Investigation:**
+
 1. Filter traces by error status
 2. Examine error messages in span events
 3. Check audit logs for detailed error information
 4. Verify external API availability
 
 **Remediation:**
+
 - Review GitHub App permissions
 - Verify Buildkite API token scopes
 - Check profile match conditions
@@ -161,12 +172,14 @@ Internal span: refresh_organization_profile
 **Symptoms:** Cache hit rate below 70%
 
 **Investigation:**
+
 1. Calculate hit/miss/mismatch ratio using `token.cache.outcome`
 2. Check token expiry times in audit logs
 3. Review repository access patterns
 4. Examine profile configurations
 
 **Remediation:**
+
 - Increase token expiry duration (if GitHub App allows)
 - Consolidate repository access patterns
 - Review profile match conditions
@@ -178,6 +191,7 @@ Internal span: refresh_organization_profile
 **Symptoms:** The `cache.encryption.total` counter increases with `encryption.outcome="error"`, or trace spans show `cache.encrypt.outcome="error"` or `cache.decrypt.outcome="error"`. Decrypt failures surface as cache misses (the service falls back to API calls). Encrypt failures prevent caching of new tokens.
 
 **Investigation:**
+
 1. Check error rate by operation type (encrypt vs decrypt) using `cache.encryption.total`
 2. Filter trace spans for `cache.decrypt.outcome="error"` or `cache.encrypt.outcome="error"` to correlate errors with specific requests
 3. Review service logs for specific error messages — decrypt errors fall into three categories:
@@ -187,6 +201,7 @@ Internal span: refresh_organization_profile
 4. Check logs for keyset refresh warnings (`"failed to refresh encryption keyset"`)
 
 **Remediation:**
+
 - Prefix errors during encryption rollout are expected — unencrypted entries resolve as cached tokens expire (within 15 minutes)
 - Decryption failures after key rotation: verify the rotation procedure in the [distributed cache guide](./distributed-cache) and confirm the old primary key was not disabled before cached tokens expired
 - Keyset refresh warnings: verify IAM permissions for Secrets Manager and KMS, then check service health

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -24,23 +24,27 @@ import { Card, CardGrid } from "@astrojs/starlight/components"
 
 <CardGrid stagger>
   <Card title="Security" icon="seti:license">
-    Authenticate to GitHub using short-lived tokens instead of long-lived PATs or deploy keys.
-    Manage one GitHub application instead of hundreds of secrets across the organization.
+    Authenticate to GitHub using short-lived tokens instead of long-lived PATs
+    or deploy keys. Manage one GitHub application instead of hundreds of secrets
+    across the organization.
   </Card>
   <Card title="Simplicity" icon="rocket">
-    GitHub access for new pipelines is automatic, and additional access permissions can be granted
-    centrally in a fully visible and auditable fashion.
+    GitHub access for new pipelines is automatic, and additional access
+    permissions can be granted centrally in a fully visible and auditable
+    fashion.
   </Card>
   <Card title="Self-hosted" icon="laptop">
-    Like the Elastic Stack, BYO compute. Your environment, your security. Fits your
-    existing compliance requirements and infrastructure.
+    Like the Elastic Stack, BYO compute. Your environment, your security. Fits
+    your existing compliance requirements and infrastructure.
   </Card>
   <Card title="Visibility" icon="magnifier">
-    Audit logs give clarity over access: pipelines, repositories and permissions are fully visible
-    and auditable. Errors are also recorded for later analysis as required.
+    Audit logs give clarity over access: pipelines, repositories and permissions
+    are fully visible and auditable. Errors are also recorded for later analysis
+    as required.
   </Card>
   <Card title="Easy integration" icon="setting">
-    Designed with Buildkite in mind, Chinmina Bridge provides plugins that make integration seamless.
-    Full or partial cutover? Your choice. Progressive adoption is easy.
+    Designed with Buildkite in mind, Chinmina Bridge provides plugins that make
+    integration seamless. Full or partial cutover? Your choice. Progressive
+    adoption is easy.
   </Card>
 </CardGrid>

--- a/src/content/docs/reference/api/health-check-and-status.md
+++ b/src/content/docs/reference/api/health-check-and-status.md
@@ -25,9 +25,9 @@ This endpoint is not authenticated and takes no parameters.
 
 The endpoint returns an HTTP status code with no response body:
 
-| Status Code           | Meaning                                                  |
-| --------------------- | -------------------------------------------------------- |
-| `200 OK`              | Service is running and accepting requests                |
+| Status Code               | Meaning                                                  |
+| ------------------------- | -------------------------------------------------------- |
+| `200 OK`                  | Service is running and accepting requests                |
 | `503 Service Unavailable` | Service is not ready (typically during startup/shutdown) |
 
 ### Example request

--- a/src/content/docs/reference/api/organization-git-credentials.md
+++ b/src/content/docs/reference/api/organization-git-credentials.md
@@ -52,6 +52,7 @@ handling.
 The `{profile}` path parameter specifies which organization profile to use. Profile names are used directly without prefixes.
 
 Examples:
+
 - `POST /organization/git-credentials/deploy`
 - `POST /organization/git-credentials/package-registry`
 - `POST /organization/git-credentials/buildkite-plugin`

--- a/src/content/docs/reference/api/organization-token.md
+++ b/src/content/docs/reference/api/organization-token.md
@@ -44,6 +44,7 @@ repositories and permissions for different use cases.
 The `{profile}` path parameter specifies which organization profile to use. Profile names are used directly without prefixes.
 
 Examples:
+
 - `POST /organization/token/deploy`
 - `POST /organization/token/package-registry`
 - `POST /organization/token/buildkite-plugin`
@@ -63,7 +64,7 @@ The request body is expected to be empty.
   "organizationSlug": "my-org",
   "profile": "release-publisher",
   "repositoryUrl": "",
-  "repositories": {"names": ["owner/release-tools", "owner/shared-infra"]},
+  "repositories": { "names": ["owner/release-tools", "owner/shared-infra"] },
   "permissions": ["metadata:read", "contents:write", "packages:write"],
   "token": "ghs_...",
   "hashedToken": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
@@ -73,16 +74,16 @@ The request body is expected to be empty.
 
 For wildcard profiles (configured with `repositories: ["*"]`), the `repositories` field is `{"wildcard": true}` rather than a named list.
 
-| Field              | Type   | Description                                                             |
-| ------------------ | ------ | ----------------------------------------------------------------------- |
-| `organizationSlug` | string | Buildkite organization from JWT claims                                  |
-| `profile`          | string | Profile identifier that was used                                        |
-| `repositoryUrl`    | string | Always empty for organization profile requests                          |
+| Field              | Type   | Description                                                                                                                                                                                       |
+| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `organizationSlug` | string | Buildkite organization from JWT claims                                                                                                                                                            |
+| `profile`          | string | Profile identifier that was used                                                                                                                                                                  |
+| `repositoryUrl`    | string | Always empty for organization profile requests                                                                                                                                                    |
 | `repositories`     | object | Repositories the token has access to. Either `{"wildcard": true}` (all repositories accessible to the GitHub App installation) or `{"names": ["owner/repo", ...]}` (specific named repositories). |
-| `permissions`      | array  | Permissions granted. Always includes `metadata:read` plus configured permissions. |
-| `token`            | string | GitHub installation token (format: `ghs_...`)                           |
-| `hashedToken`      | string | SHA-256 hash of the token, base64-encoded (`base64(SHA-256(token))`). Use to correlate with [GitHub organisation audit log events][gh-audit-token] for the same token. |
-| `expiry`           | string | ISO 8601 timestamp when token expires                                   |
+| `permissions`      | array  | Permissions granted. Always includes `metadata:read` plus configured permissions.                                                                                                                 |
+| `token`            | string | GitHub installation token (format: `ghs_...`)                                                                                                                                                     |
+| `hashedToken`      | string | SHA-256 hash of the token, base64-encoded (`base64(SHA-256(token))`). Use to correlate with [GitHub organisation audit log events][gh-audit-token] for the same token.                            |
+| `expiry`           | string | ISO 8601 timestamp when token expires                                                                                                                                                             |
 
 ### Empty response (200 OK)
 

--- a/src/content/docs/reference/api/pipeline-token.md
+++ b/src/content/docs/reference/api/pipeline-token.md
@@ -79,7 +79,7 @@ When a token is successfully vended, the response is a JSON object:
   "organizationSlug": "my-org",
   "profile": "org:default",
   "repositoryUrl": "https://github.com/owner/repository",
-  "repositories": {"names": ["owner/repository"]},
+  "repositories": { "names": ["owner/repository"] },
   "permissions": ["metadata:read", "contents:read"],
   "token": "ghs_...",
   "hashedToken": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
@@ -87,16 +87,16 @@ When a token is successfully vended, the response is a JSON object:
 }
 ```
 
-| Field              | Type   | Description                                                             |
-| ------------------ | ------ | ----------------------------------------------------------------------- |
-| `organizationSlug` | string | Buildkite organization from JWT claims                                  |
-| `profile`          | string | Profile identifier that was used                                        |
-| `repositoryUrl`    | string | The requested repository URL: this will always be empty                 |
+| Field              | Type   | Description                                                                                                                                                                                       |
+| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `organizationSlug` | string | Buildkite organization from JWT claims                                                                                                                                                            |
+| `profile`          | string | Profile identifier that was used                                                                                                                                                                  |
+| `repositoryUrl`    | string | The requested repository URL: this will always be empty                                                                                                                                           |
 | `repositories`     | object | Repositories the token has access to. Either `{"wildcard": true}` (all repositories accessible to the GitHub App installation) or `{"names": ["owner/repo", ...]}` (specific named repositories). |
-| `permissions`      | array  | Permissions granted. Always includes `metadata:read` plus configured permissions. |
-| `token`            | string | GitHub installation token (format: `ghs_...`)                           |
-| `hashedToken`      | string | SHA-256 hash of the token, base64-encoded (`base64(SHA-256(token))`). Use to correlate with [GitHub organisation audit log events][gh-audit-token] for the same token. |
-| `expiry`           | string | ISO 8601 timestamp when token expires                                   |
+| `permissions`      | array  | Permissions granted. Always includes `metadata:read` plus configured permissions.                                                                                                                 |
+| `token`            | string | GitHub installation token (format: `ghs_...`)                                                                                                                                                     |
+| `hashedToken`      | string | SHA-256 hash of the token, base64-encoded (`base64(SHA-256(token))`). Use to correlate with [GitHub organisation audit log events][gh-audit-token] for the same token.                            |
+| `expiry`           | string | ISO 8601 timestamp when token expires                                                                                                                                                             |
 
 ### Error responses
 

--- a/src/content/docs/reference/profiles/matching.mdx
+++ b/src/content/docs/reference/profiles/matching.mdx
@@ -49,7 +49,7 @@ Use `value` for known strings. This is the fastest match type.
 ```yaml
 match:
   - claim: pipeline_slug
-    value: "silk-prod"  # Matches only "silk-prod"
+    value: "silk-prod" # Matches only "silk-prod"
 ```
 
 ### Regex matching
@@ -59,7 +59,7 @@ Use `valuePattern` for flexible patterns. Supports [RE2 regex syntax](https://gi
 ```yaml
 match:
   - claim: pipeline_slug
-    valuePattern: ".*-release"  # Matches any pipeline ending in "-release"
+    valuePattern: ".*-release" # Matches any pipeline ending in "-release"
 ```
 
 #### Anchoring
@@ -74,7 +74,8 @@ For example:
 2. For partial matches: `.*-prod` matches "silk-prod" and "cotton-prod".
 
 <Aside type="tip">
-While pattern matching allows flexibility, prefer exact matches when possible for simplicity.
+  While pattern matching allows flexibility, prefer exact matches when possible
+  for simplicity.
 </Aside>
 
 ### Multiple conditions
@@ -94,17 +95,17 @@ match:
 
 Match rules can evaluate the following JWT claims from the Buildkite OIDC token:
 
-| Claim | Description |
-|-------|-------------|
-| `pipeline_slug` | Pipeline's slug |
-| `pipeline_id` | Pipeline UUID |
-| `build_number` | Build number (as string) |
-| `build_branch` | Git branch name |
-| `build_tag` | Git tag (if present) |
-| `build_commit` | Git commit SHA |
-| `cluster_id`, `cluster_name` | Cluster identifiers |
-| `queue_id`, `queue_key` | Queue identifiers |
-| `agent_tag:NAME` | Dynamic agent tags (e.g., `agent_tag:queue`) |
+| Claim                        | Description                                  |
+| ---------------------------- | -------------------------------------------- |
+| `pipeline_slug`              | Pipeline's slug                              |
+| `pipeline_id`                | Pipeline UUID                                |
+| `build_number`               | Build number (as string)                     |
+| `build_branch`               | Git branch name                              |
+| `build_tag`                  | Git tag (if present)                         |
+| `build_commit`               | Git commit SHA                               |
+| `cluster_id`, `cluster_name` | Cluster identifiers                          |
+| `queue_id`, `queue_key`      | Queue identifiers                            |
+| `agent_tag:NAME`             | Dynamic agent tags (e.g., `agent_tag:queue`) |
 
 <Aside type="tip">
 
@@ -162,7 +163,7 @@ match:
 ```yaml
 match:
   - claim: build_tag
-    valuePattern: "v[0-9]+\\.[0-9]+\\.[0-9]+"  # v1.2.3 format
+    valuePattern: "v[0-9]+\\.[0-9]+\\.[0-9]+" # v1.2.3 format
 ```
 
 ## Troubleshooting
@@ -196,6 +197,7 @@ Replace `.*` with more specific patterns when possible.
 Invalid RE2 regex syntax.
 
 Consult the [RE2 syntax guide](https://github.com/google/re2/wiki/Syntax) for supported patterns. Common issues:
+
 - Backreferences are not supported
 - Some Perl regex features are unavailable
 - Escape special characters with backslash

--- a/src/content/docs/reference/profiles/organization.md
+++ b/src/content/docs/reference/profiles/organization.md
@@ -60,6 +60,7 @@ _(optional)_
 Claim matching rules that restrict which pipelines can use this profile. Omit this field entirely to make the profile available to all pipelines.
 
 See the [profile matching reference](matching) for complete details on:
+
 - Match rule syntax (exact vs regex matching)
 - Available claims
 - Pattern examples
@@ -110,6 +111,7 @@ pipeline:
 ## Accessing organization profiles
 
 Organization profiles are requested via:
+
 - `/organization/token/{profile}` for JSON token responses
 - `/organization/git-credentials/{profile}` for Git credential helper format
 

--- a/src/content/docs/reference/profiles/pipeline.md
+++ b/src/content/docs/reference/profiles/pipeline.md
@@ -48,6 +48,7 @@ _(optional)_
 Claim matching rules that restrict which pipelines can use this profile. Omit this field entirely to make the profile available to all pipelines.
 
 See the [profile matching reference](matching) for complete details on:
+
 - Match rule syntax (exact vs regex matching)
 - Available claims
 - Pattern examples
@@ -89,6 +90,7 @@ pipeline:
 ## Accessing pipeline profiles
 
 Pipeline profiles are requested via:
+
 - `/token/{profile}` for JSON token responses
 - `/git-credentials/{profile}` for Git credential helper format
 
@@ -100,8 +102,8 @@ The [Chinmina Token plugin][chinmina-token] and [Chinmina Git Credentials plugin
 
 ```yaml
 environment:
-  - GITHUB_TOKEN=pipeline:default       # pipeline defaults
-  - PR_TOKEN=pipeline:pr-commenter      # named pipeline profile
+  - GITHUB_TOKEN=pipeline:default # pipeline defaults
+  - PR_TOKEN=pipeline:pr-commenter # named pipeline profile
 ```
 
 The plugins translate these to appropriate API paths (`/token/default`, `/token/pr-commenter`).

--- a/src/content/docs/reference/telemetry/index.md
+++ b/src/content/docs/reference/telemetry/index.md
@@ -40,6 +40,7 @@ Two exporter types are available:
 The gRPC exporter sends telemetry to an OpenTelemetry collector via gRPC protocol. This is the default and recommended exporter for production use.
 
 Configuration uses standard OpenTelemetry environment variables:
+
 - `OTEL_EXPORTER_OTLP_ENDPOINT`
 - `OTEL_EXPORTER_OTLP_HEADERS`
 - `OTEL_EXPORTER_OTLP_TIMEOUT`

--- a/src/content/docs/reference/telemetry/metrics.md
+++ b/src/content/docs/reference/telemetry/metrics.md
@@ -51,19 +51,19 @@ Counts cache operations performed.
 
 ### Attributes
 
-| Attribute | Type | Values |
-|-----------|------|--------|
-| `cache.type` | string | Cache implementation type (e.g., `"token"`) |
-| `cache.operation` | string | `"get"`, `"set"`, `"invalidate"` |
-| `cache.status` | string | `"hit"`, `"miss"`, `"error"`, `"success"` |
+| Attribute         | Type   | Values                                      |
+| ----------------- | ------ | ------------------------------------------- |
+| `cache.type`      | string | Cache implementation type (e.g., `"token"`) |
+| `cache.operation` | string | `"get"`, `"set"`, `"invalidate"`            |
+| `cache.status`    | string | `"hit"`, `"miss"`, `"error"`, `"success"`   |
 
 ### Status semantics
 
-| Operation | Success Status | Failure Status |
-|-----------|----------------|----------------|
-| `get` | `"hit"` or `"miss"` | `"error"` |
-| `set` | `"success"` | `"error"` |
-| `invalidate` | `"success"` | `"error"` |
+| Operation    | Success Status      | Failure Status |
+| ------------ | ------------------- | -------------- |
+| `get`        | `"hit"` or `"miss"` | `"error"`      |
+| `set`        | `"success"`         | `"error"`      |
+| `invalidate` | `"success"`         | `"error"`      |
 
 **Note:** For `get` operations, `"hit"` indicates a cached value was found, `"miss"` indicates no cached value exists, and `"error"` indicates the cache operation failed.
 
@@ -79,10 +79,10 @@ Measures duration of cache operations.
 
 ### Attributes
 
-| Attribute | Type | Values |
-|-----------|------|--------|
-| `cache.type` | string | Cache implementation type (e.g., `"token"`) |
-| `cache.operation` | string | `"get"`, `"set"`, `"invalidate"` |
+| Attribute         | Type   | Values                                      |
+| ----------------- | ------ | ------------------------------------------- |
+| `cache.type`      | string | Cache implementation type (e.g., `"token"`) |
+| `cache.operation` | string | `"get"`, `"set"`, `"invalidate"`            |
 
 Duration is measured from operation start to completion. The metric is recorded before the operation status is determined, so duration histograms include both successful and failed operations.
 
@@ -102,8 +102,8 @@ These metrics are only produced when the distributed cache is configured with en
 
 ### Attributes
 
-| Attribute | Type | Values |
-|-----------|------|--------|
+| Attribute              | Type   | Values                   |
+| ---------------------- | ------ | ------------------------ |
 | `encryption.operation` | string | `"encrypt"`, `"decrypt"` |
 
 ## cache.encryption.total
@@ -118,10 +118,10 @@ Counts encrypt and decrypt operations.
 
 ### Attributes
 
-| Attribute | Type | Values |
-|-----------|------|--------|
+| Attribute              | Type   | Values                   |
+| ---------------------- | ------ | ------------------------ |
 | `encryption.operation` | string | `"encrypt"`, `"decrypt"` |
-| `encryption.outcome` | string | `"success"`, `"error"` |
+| `encryption.outcome`   | string | `"success"`, `"error"`   |
 
 ## token.cache.outcome
 
@@ -135,16 +135,16 @@ Counts token cache lookup outcomes in the vendor layer.
 
 ### Attributes
 
-| Attribute | Type | Values | Description |
-|-----------|------|--------|-------------|
+| Attribute            | Type   | Values                          | Description    |
+| -------------------- | ------ | ------------------------------- | -------------- |
 | `token.cache.result` | string | `"hit"`, `"miss"`, `"mismatch"` | Lookup outcome |
 
 ### Result semantics
 
-| Result | Meaning |
-|--------|---------|
-| `"hit"` | Cached token found and repository matches request |
-| `"miss"` | No cached token found or cache error occurred |
+| Result       | Meaning                                                                      |
+| ------------ | ---------------------------------------------------------------------------- |
+| `"hit"`      | Cached token found and repository matches request                            |
+| `"miss"`     | No cached token found or cache error occurred                                |
 | `"mismatch"` | Cached token found but repository does not match request (cache invalidated) |
 
 A `"mismatch"` result occurs when a cached token exists but was vended for a different repository than the current request. In this case, the cache is invalidated and a new token is generated.
@@ -161,13 +161,14 @@ hit_rate = hits / (hits + misses + mismatches)
 
 The `cache.type` attribute distinguishes between different cache instances. Current values:
 
-| Cache Type | Value |
-|------------|-------|
+| Cache Type         | Value     |
+| ------------------ | --------- |
 | Token vendor cache | `"token"` |
 
 ## Configuration
 
 For metric configuration details, see:
+
 - [Configuration reference](../configuration) for `OBSERVE_METRICS_*` variables
 - [Observability guide](../../guides/observability) for setup instructions
 

--- a/src/content/docs/reference/telemetry/traces.md
+++ b/src/content/docs/reference/telemetry/traces.md
@@ -21,20 +21,21 @@ HTTP server spans represent incoming requests to Chinmina endpoints.
 
 Attributes are added automatically by the `otelhttp` package following OpenTelemetry HTTP semantic conventions. Common attributes include:
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `http.request.method` | string | HTTP method (GET, POST) |
-| `http.route` | string | Matched route pattern (e.g., `/token`) |
-| `url.path` | string | Request path |
-| `url.scheme` | string | Protocol (http or https) |
-| `http.response.status_code` | int | HTTP response status code |
-| `network.protocol.version` | string | HTTP version (e.g., "1.1") |
-| `user_agent.original` | string | User-Agent header value |
-| `server.address` | string | Server hostname |
-| `server.port` | int | Server port |
-| `client.address` | string | Client IP address |
+| Attribute                   | Type   | Description                            |
+| --------------------------- | ------ | -------------------------------------- |
+| `http.request.method`       | string | HTTP method (GET, POST)                |
+| `http.route`                | string | Matched route pattern (e.g., `/token`) |
+| `url.path`                  | string | Request path                           |
+| `url.scheme`                | string | Protocol (http or https)               |
+| `http.response.status_code` | int    | HTTP response status code              |
+| `network.protocol.version`  | string | HTTP version (e.g., "1.1")             |
+| `user_agent.original`       | string | User-Agent header value                |
+| `server.address`            | string | Server hostname                        |
+| `server.port`               | int    | Server port                            |
+| `client.address`            | string | Client IP address                      |
 
 **Status:**
+
 - `Unset` for 1xx, 2xx, 3xx, and 4xx responses
 - `Error` for 5xx responses
 
@@ -42,17 +43,18 @@ Attributes are added automatically by the `otelhttp` package following OpenTelem
 
 The JWT validation middleware extracts Buildkite identity fields from the authenticated token and writes them to the current span. These attributes appear on every authenticated request span.
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `buildkite.organization_slug` | string | Buildkite organization |
-| `buildkite.pipeline_slug` | string | Pipeline that initiated the request |
-| `buildkite.job_id` | string | Job ID |
-| `buildkite.build_number` | int | Build number |
-| `buildkite.build_branch` | string | Branch being built |
+| Attribute                     | Type   | Description                         |
+| ----------------------------- | ------ | ----------------------------------- |
+| `buildkite.organization_slug` | string | Buildkite organization              |
+| `buildkite.pipeline_slug`     | string | Pipeline that initiated the request |
+| `buildkite.job_id`            | string | Job ID                              |
+| `buildkite.build_number`      | int    | Build number                        |
+| `buildkite.build_branch`      | string | Branch being built                  |
 
 ### Instrumented endpoints
 
 All authenticated endpoints create server spans:
+
 - `POST /token`
 - `POST /git-credentials`
 - `POST /organization/token/{profile}`
@@ -76,14 +78,14 @@ HTTP client spans represent outgoing requests to external APIs.
 
 Attributes are added by the `otelhttp` package. Common attributes include:
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `http.request.method` | string | HTTP method (GET, POST, etc.) |
-| `url.full` | string | Full request URL |
-| `http.response.status_code` | int | HTTP response status code |
-| `url.path` | string | Request path |
-| `server.address` | string | Target hostname |
-| `server.port` | int | Target port |
+| Attribute                   | Type   | Description                   |
+| --------------------------- | ------ | ----------------------------- |
+| `http.request.method`       | string | HTTP method (GET, POST, etc.) |
+| `url.full`                  | string | Full request URL              |
+| `http.response.status_code` | int    | HTTP response status code     |
+| `url.path`                  | string | Request path                  |
+| `server.address`            | string | Target hostname               |
+| `server.port`               | int    | Target port                   |
 
 ### Connection trace attributes
 
@@ -99,6 +101,7 @@ These attributes are added to the parent HTTP client span rather than creating s
 ### External services
 
 Client spans are created for requests to:
+
 - **GitHub API** (`api.github.com`): Token generation requests
 - **Buildkite API** (`api.buildkite.com`): Pipeline repository lookups
 
@@ -118,21 +121,21 @@ The profile refresh span represents periodic background operations that fetch an
 
 ### Profile refresh attributes
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
+| Attribute                | Type   | Description                                                    |
+| ------------------------ | ------ | -------------------------------------------------------------- |
 | `profile.digest_current` | string | SHA-256 digest of previous profile configuration (hex-encoded) |
-| `profile.digest_updated` | string | SHA-256 digest of new profile configuration (hex-encoded) |
-| `profile.digest_changed` | bool | Whether configuration content changed |
+| `profile.digest_updated` | string | SHA-256 digest of new profile configuration (hex-encoded)      |
+| `profile.digest_changed` | bool   | Whether configuration content changed                          |
 
 Attributes are added during the profile update process, after the new profile is computed but before it is stored.
 
 ### Status codes
 
-| Condition | Status Code | Status Message |
-|-----------|-------------|----------------|
-| Success | `Ok` | `"profile refreshed"` |
-| Panic during refresh | `Error` | `"profile refresh panicked"` |
-| Fetch failure | `Error` | `"profile refresh failed"` |
+| Condition            | Status Code | Status Message               |
+| -------------------- | ----------- | ---------------------------- |
+| Success              | `Ok`        | `"profile refreshed"`        |
+| Panic during refresh | `Error`     | `"profile refresh panicked"` |
+| Fetch failure        | `Error`     | `"profile refresh failed"`   |
 
 **Error recording:** Errors are recorded on the span via `span.RecordError()` before setting the error status.
 
@@ -144,11 +147,11 @@ Profile refresh operations create child HTTP client spans for requests to the Gi
 
 Each cache operation (get, set, invalidate) writes its result and timing directly to the active span. These attributes appear alongside the HTTP server span attributes on the parent request.
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `cache.type` | string | Cache backend (`"memory"` or `"distributed"`) |
-| `cache.{operation}.status` | string | Outcome of the operation |
-| `cache.{operation}.duration` | float64 | Duration in seconds |
+| Attribute                    | Type    | Description                                   |
+| ---------------------------- | ------- | --------------------------------------------- |
+| `cache.type`                 | string  | Cache backend (`"memory"` or `"distributed"`) |
+| `cache.{operation}.status`   | string  | Outcome of the operation                      |
+| `cache.{operation}.duration` | float64 | Duration in seconds                           |
 
 Where `{operation}` is one of `get`, `set`, or `invalidate`.
 
@@ -156,10 +159,10 @@ Where `{operation}` is one of `get`, `set`, or `invalidate`.
 
 When cache encryption is active, encrypt and decrypt operations write timing and outcome attributes to the active span.
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `cache.{operation}.duration` | float64 | Duration in seconds |
-| `cache.{operation}.outcome` | string | `"success"` or `"error"` |
+| Attribute                    | Type    | Description              |
+| ---------------------------- | ------- | ------------------------ |
+| `cache.{operation}.duration` | float64 | Duration in seconds      |
+| `cache.{operation}.outcome`  | string  | `"success"` or `"error"` |
 
 Where `{operation}` is `encrypt` or `decrypt`.
 
@@ -187,6 +190,7 @@ Internal span: refresh_organization_profile
 ## Span volume
 
 With full tracing enabled, each token request generates:
+
 - 1 server span (incoming request)
 - 1–2 client spans (Buildkite API + GitHub API)
 - Connection timing attributes on client spans (if `OBSERVE_CONNECTION_TRACE_ENABLED=true`)
@@ -198,5 +202,6 @@ Background profile refresh operations generate additional traces periodically ba
 ## Configuration
 
 For span configuration details, see:
+
 - [Configuration reference](../configuration) for `OBSERVE_*` variables
 - [Observability guide](../../guides/observability) for setup instructions

--- a/src/integrations/markdown-pages.mjs
+++ b/src/integrations/markdown-pages.mjs
@@ -1,6 +1,6 @@
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs"
-import { resolve, dirname, join } from "node:path"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { glob } from "node:fs/promises"
+import { dirname, join, resolve } from "node:path"
 import { transformMarkdown } from "./transform.mjs"
 
 /**
@@ -11,16 +11,22 @@ function parseFrontmatterFields(frontmatter) {
   const result = {}
   for (const line of frontmatter.split("\n")) {
     const m = line.match(/^(title|description):\s*(.+)$/)
-    if (m) result[m[1]] = m[2].trim().replace(/^["']|["']$/g, "")
+    if (m) {
+      result[m[1]] = m[2].trim().replace(/^["']|["']$/g, "")
+    }
   }
   return result
 }
 
 /** Extract raw frontmatter block (including --- delimiters) from file content. */
 function extractFrontmatterBlock(content) {
-  if (!content.startsWith("---")) return null
+  if (!content.startsWith("---")) {
+    return null
+  }
   const end = content.indexOf("\n---", 3)
-  if (end === -1) return null
+  if (end === -1) {
+    return null
+  }
   return content.slice(0, end + 4)
 }
 
@@ -54,7 +60,14 @@ function flattenSlugs(items) {
  * @param {string} opts.docsDir  absolute path to src/content/docs
  * @param {Map<string, {title?: string, description?: string}>} pageCache  slug → metadata
  */
-async function generateLlmsTxt({ siteTitle, siteDescription, sidebar, siteUrl, docsDir, pageCache }) {
+async function generateLlmsTxt({
+  siteTitle,
+  siteDescription,
+  sidebar,
+  siteUrl,
+  docsDir,
+  pageCache,
+}) {
   const lines = []
   lines.push(`# ${siteTitle}`, "")
   if (siteDescription) {
@@ -73,7 +86,9 @@ async function generateLlmsTxt({ siteTitle, siteDescription, sidebar, siteUrl, d
       const dir = section.autogenerate.directory
       const found = []
       for await (const file of glob(`${dir}/**/*.{md,mdx}`, { cwd: docsDir })) {
-        found.push(file.replace(/\/index\.(md|mdx)$/, "").replace(/\.(md|mdx)$/, ""))
+        found.push(
+          file.replace(/\/index\.(md|mdx)$/, "").replace(/\.(md|mdx)$/, ""),
+        )
       }
       found.sort()
       slugs = found
@@ -86,7 +101,11 @@ async function generateLlmsTxt({ siteTitle, siteDescription, sidebar, siteUrl, d
       // Index pages live at [slug]/index.md, not [slug].md
       const mdFile = meta?._isIndex ? `${slug}/index.md` : `${slug}.md`
       const url = `${siteUrl}/${mdFile}`
-      lines.push(description ? `- [${title}](${url}): ${description}` : `- [${title}](${url})`)
+      lines.push(
+        description
+          ? `- [${title}](${url}): ${description}`
+          : `- [${title}](${url})`,
+      )
     }
     lines.push("")
   }
@@ -106,7 +125,11 @@ async function generateLlmsTxt({ siteTitle, siteDescription, sidebar, siteUrl, d
  * - Build: writes transformed `.md` files alongside HTML output in `dist/`,
  *          and generates `llms.txt` at the root if sidebar config is provided
  */
-export default function markdownPages({ sidebar, siteTitle, siteDescription } = {}) {
+export default function markdownPages({
+  sidebar,
+  siteTitle,
+  siteDescription,
+} = {}) {
   let siteUrl = ""
 
   return {
@@ -121,22 +144,26 @@ export default function markdownPages({ sidebar, siteTitle, siteDescription } = 
         const devDocsDir = resolve("src/content/docs")
         server.middlewares.use(async (req, res, next) => {
           const url = req.url ?? ""
-          if (!url.endsWith(".md")) return next()
+          if (!url.endsWith(".md")) {
+            return next()
+          }
 
           // Map URL path to source file: strip leading `/` and `.md` suffix
           const urlPath = url.replace(/\.md$/, "").replace(/^\//, "")
           const srcBase = resolve(devDocsDir, urlPath)
 
           // Reject paths that escape the docs root
-          if (!srcBase.startsWith(devDocsDir + "/") && srcBase !== devDocsDir) return next()
+          if (!srcBase.startsWith(`${devDocsDir}/`) && srcBase !== devDocsDir) {
+            return next()
+          }
 
           let content, isMdx
           try {
             try {
-              content = readFileSync(srcBase + ".mdx", "utf8")
+              content = readFileSync(`${srcBase}.mdx`, "utf8")
               isMdx = true
             } catch {
-              content = readFileSync(srcBase + ".md", "utf8")
+              content = readFileSync(`${srcBase}.md`, "utf8")
               isMdx = false
             }
           } catch {
@@ -168,9 +195,13 @@ export default function markdownPages({ sidebar, siteTitle, siteDescription } = 
 
           // Normalize slug: strip /index suffix so it matches sidebar entries
           const isIndex = /\/index\.(md|mdx)$/.test(file)
-          const slug = isIndex ? file.replace(/\/index\.(md|mdx)$/, "") : file.replace(/\.(md|mdx)$/, "")
+          const slug = isIndex
+            ? file.replace(/\/index\.(md|mdx)$/, "")
+            : file.replace(/\.(md|mdx)$/, "")
           const frontmatterBlock = extractFrontmatterBlock(content)
-          const fields = frontmatterBlock ? parseFrontmatterFields(frontmatterBlock) : {}
+          const fields = frontmatterBlock
+            ? parseFrontmatterFields(frontmatterBlock)
+            : {}
           pageCache.set(slug, { ...fields, _isIndex: isIndex })
 
           const transformed = await transformMarkdown(content, { isMdx })

--- a/src/integrations/transform.mjs
+++ b/src/integrations/transform.mjs
@@ -1,8 +1,8 @@
-import { unified } from "unified"
-import remarkParse from "remark-parse"
-import remarkMdx from "remark-mdx"
 import remarkDirective from "remark-directive"
+import remarkMdx from "remark-mdx"
+import remarkParse from "remark-parse"
 import remarkStringify from "remark-stringify"
+import { unified } from "unified"
 
 /**
  * Walk all nodes in a unist tree, calling visitor(node, index, parent) for each.
@@ -11,7 +11,9 @@ import remarkStringify from "remark-stringify"
 function walk(tree, visitor) {
   function traverse(node, index, parent) {
     const result = visitor(node, index, parent)
-    if (result === false) return
+    if (result === false) {
+      return
+    }
     if (node.children) {
       for (let i = 0; i < node.children.length; i++) {
         traverse(node.children[i], i, node)
@@ -28,22 +30,37 @@ function walk(tree, visitor) {
 function remarkRewriteLinks() {
   return (tree) => {
     walk(tree, (node) => {
-      if (node.type !== "link") return
+      if (node.type !== "link") {
+        return
+      }
       const url = node.url
-      if (!url) return
-      if (url.startsWith("http://") || url.startsWith("https://") || url.startsWith("#")) return
+      if (!url) {
+        return
+      }
+      if (
+        url.startsWith("http://") ||
+        url.startsWith("https://") ||
+        url.startsWith("#")
+      ) {
+        return
+      }
 
       const hashIndex = url.indexOf("#")
       if (hashIndex === -1) {
-        node.url = url + ".md"
+        node.url = `${url}.md`
       } else {
-        node.url = url.slice(0, hashIndex) + ".md" + url.slice(hashIndex)
+        node.url = `${url.slice(0, hashIndex)}.md${url.slice(hashIndex)}`
       }
     })
   }
 }
 
-const DIRECTIVE_TYPE_LABEL = { note: "NOTE", tip: "TIP", caution: "CAUTION", danger: "WARNING" }
+const DIRECTIVE_TYPE_LABEL = {
+  note: "NOTE",
+  tip: "TIP",
+  caution: "CAUTION",
+  danger: "WARNING",
+}
 
 /**
  * Remark plugin: convert :::note/tip/caution/danger container directives
@@ -54,12 +71,18 @@ function remarkDirectivesToBlockquotes() {
     function convert(nodes) {
       for (let i = 0; i < nodes.length; i++) {
         const node = nodes[i]
-        if (node.type === "containerDirective" && DIRECTIVE_TYPE_LABEL[node.name]) {
+        if (
+          node.type === "containerDirective" &&
+          DIRECTIVE_TYPE_LABEL[node.name]
+        ) {
           const label = DIRECTIVE_TYPE_LABEL[node.name]
           nodes[i] = {
             type: "blockquote",
             children: [
-              { type: "paragraph", children: [{ type: "text", value: `[!${label}]` }] },
+              {
+                type: "paragraph",
+                children: [{ type: "text", value: `[!${label}]` }],
+              },
               ...(node.children ?? []),
             ],
           }
@@ -103,13 +126,21 @@ const COMPONENT_TRANSLATIONS = {
   Aside(node) {
     const typeAttr = node.attributes?.find((a) => a.name === "type")
     const type = typeAttr?.value ?? "note"
-    const TYPE_LABEL = { note: "NOTE", tip: "TIP", caution: "CAUTION", danger: "WARNING" }
+    const TYPE_LABEL = {
+      note: "NOTE",
+      tip: "TIP",
+      caution: "CAUTION",
+      danger: "WARNING",
+    }
     const label = TYPE_LABEL[type] ?? "NOTE"
     return [
       {
         type: "blockquote",
         children: [
-          { type: "paragraph", children: [{ type: "text", value: `[!${label}]` }] },
+          {
+            type: "paragraph",
+            children: [{ type: "text", value: `[!${label}]` }],
+          },
           ...(node.children ?? []),
         ],
       },
@@ -127,7 +158,11 @@ const COMPONENT_TRANSLATIONS = {
  */
 function remarkStripMdx() {
   return (tree) => {
-    const STRIP_TYPES = new Set(["mdxjsEsm", "mdxFlowExpression", "mdxTextExpression"])
+    const STRIP_TYPES = new Set([
+      "mdxjsEsm",
+      "mdxFlowExpression",
+      "mdxTextExpression",
+    ])
 
     function unwrap(nodes) {
       for (let i = 0; i < nodes.length; i++) {
@@ -136,12 +171,15 @@ function remarkStripMdx() {
           nodes.splice(i, 1)
           i--
         } else if (
-          (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") &&
+          (node.type === "mdxJsxFlowElement" ||
+            node.type === "mdxJsxTextElement") &&
           node.name &&
           /^[A-Z]/.test(node.name)
         ) {
           const translator = COMPONENT_TRANSLATIONS[node.name]
-          const replacement = translator ? translator(node) : (node.children ?? [])
+          const replacement = translator
+            ? translator(node)
+            : (node.children ?? [])
           nodes.splice(i, 1, ...replacement)
           i-- // re-examine from same index; recurse into replacement children
         } else if (node.children) {
@@ -159,9 +197,13 @@ function remarkStripMdx() {
  * or { frontmatter: null, body: content } if none found.
  */
 function extractFrontmatter(content) {
-  if (!content.startsWith("---")) return { frontmatter: null, body: content }
+  if (!content.startsWith("---")) {
+    return { frontmatter: null, body: content }
+  }
   const end = content.indexOf("\n---", 3)
-  if (end === -1) return { frontmatter: null, body: content }
+  if (end === -1) {
+    return { frontmatter: null, body: content }
+  }
   const frontmatter = content.slice(0, end + 4) // include closing ---
   const body = content.slice(end + 4)
   return { frontmatter, body }
@@ -177,7 +219,10 @@ function extractFrontmatter(content) {
 export async function transformMarkdown(content, { isMdx = false } = {}) {
   const { frontmatter, body } = extractFrontmatter(content)
 
-  const processor = unified().use(remarkParse).use(remarkDirective).use(remarkDirectivesToBlockquotes)
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkDirective)
+    .use(remarkDirectivesToBlockquotes)
 
   if (isMdx) {
     processor.use(remarkMdx).use(remarkStripMdx)
@@ -188,5 +233,5 @@ export async function transformMarkdown(content, { isMdx = false } = {}) {
   const result = await processor.process(body)
   const transformed = String(result)
 
-  return frontmatter ? frontmatter + "\n" + transformed : transformed
+  return frontmatter ? `${frontmatter}\n${transformed}` : transformed
 }

--- a/src/integrations/transform.test.mjs
+++ b/src/integrations/transform.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest"
+import { describe, expect, it } from "vitest"
 import { transformMarkdown } from "./transform.mjs"
 
 describe("transformMarkdown — .md files", () => {
@@ -161,7 +161,9 @@ describe("transformMarkdown — .mdx files", () => {
 
 Content here.
 `
-    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+    expect(
+      await transformMarkdown(input, { isMdx: true }),
+    ).toMatchInlineSnapshot(`
       "# Page
 
       Content here.
@@ -176,7 +178,9 @@ Content here.
 
 Content here.
 `
-    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+    expect(
+      await transformMarkdown(input, { isMdx: true }),
+    ).toMatchInlineSnapshot(`
       "# Page
 
       Content here.
@@ -184,14 +188,16 @@ Content here.
     `)
   })
 
-  it("renders <Aside type=\"note\"> as GitHub blockquote admonition", async () => {
+  it('renders <Aside type="note"> as GitHub blockquote admonition', async () => {
     const input = `# Page
 
 <Aside type="note">
 This is important.
 </Aside>
 `
-    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+    expect(
+      await transformMarkdown(input, { isMdx: true }),
+    ).toMatchInlineSnapshot(`
       "# Page
 
       > \\[!NOTE]
@@ -201,14 +207,16 @@ This is important.
     `)
   })
 
-  it("renders <Aside type=\"tip\"> as [!TIP] blockquote", async () => {
+  it('renders <Aside type="tip"> as [!TIP] blockquote', async () => {
     const input = `# Page
 
 <Aside type="tip">
 A helpful tip.
 </Aside>
 `
-    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+    expect(
+      await transformMarkdown(input, { isMdx: true }),
+    ).toMatchInlineSnapshot(`
       "# Page
 
       > \\[!TIP]
@@ -218,14 +226,16 @@ A helpful tip.
     `)
   })
 
-  it("renders <Aside type=\"caution\"> as [!CAUTION] blockquote", async () => {
+  it('renders <Aside type="caution"> as [!CAUTION] blockquote', async () => {
     const input = `# Page
 
 <Aside type="caution">
 Be careful here.
 </Aside>
 `
-    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+    expect(
+      await transformMarkdown(input, { isMdx: true }),
+    ).toMatchInlineSnapshot(`
       "# Page
 
       > \\[!CAUTION]
@@ -235,12 +245,14 @@ Be careful here.
     `)
   })
 
-  it("renders <ConfigRef name=\"X\" /> as a linked inline code reference", async () => {
+  it('renders <ConfigRef name="X" /> as a linked inline code reference', async () => {
     const input = `# Page
 
 Set <ConfigRef name="JWT_BUILDKITE_ORGANIZATION_SLUG" /> to your org slug.
 `
-    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+    expect(
+      await transformMarkdown(input, { isMdx: true }),
+    ).toMatchInlineSnapshot(`
       "# Page
 
       Set [\`JWT_BUILDKITE_ORGANIZATION_SLUG\`](../reference/configuration.md#jwt_buildkite_organization_slug) to your org slug.
@@ -248,12 +260,14 @@ Set <ConfigRef name="JWT_BUILDKITE_ORGANIZATION_SLUG" /> to your org slug.
     `)
   })
 
-  it("renders inline <Later name=\"X\" /> as backtick placeholder", async () => {
+  it('renders inline <Later name="X" /> as backtick placeholder', async () => {
     const input = `# Page
 
 Save the token as <Later name="BUILDKITE_API_TOKEN" />.
 `
-    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+    expect(
+      await transformMarkdown(input, { isMdx: true }),
+    ).toMatchInlineSnapshot(`
       "# Page
 
       Save the token as \`📝 BUILDKITE_API_TOKEN\`.
@@ -268,7 +282,9 @@ Save the token as <Later name="BUILDKITE_API_TOKEN" />.
 Some content.
 </Card>
 `
-    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+    expect(
+      await transformMarkdown(input, { isMdx: true }),
+    ).toMatchInlineSnapshot(`
       "# Page
 
       Some content.
@@ -283,7 +299,9 @@ Some content.
 
 Content here.
 `
-    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+    expect(
+      await transformMarkdown(input, { isMdx: true }),
+    ).toMatchInlineSnapshot(`
       "# Page
 
       Content here.
@@ -296,7 +314,9 @@ Content here.
 
 Some text with <em>emphasis</em> and a line break.<br />
 `
-    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+    expect(
+      await transformMarkdown(input, { isMdx: true }),
+    ).toMatchInlineSnapshot(`
       "# Page
 
       Some text with <em>emphasis</em> and a line break.<br />
@@ -313,7 +333,9 @@ Some text with <em>emphasis</em> and a line break.<br />
 See [getting started](../guides/getting-started#setup).
 </Card>
 `
-    expect(await transformMarkdown(input, { isMdx: true })).toMatchInlineSnapshot(`
+    expect(
+      await transformMarkdown(input, { isMdx: true }),
+    ).toMatchInlineSnapshot(`
       "# Page
 
       See [getting started](../guides/getting-started.md#setup).


### PR DESCRIPTION
## Purpose

Introduces Biome as the single tool for formatting and linting across the repository, replacing the oxlint/oxfmt combination that was unreliable for \`.mjs\` files.

Biome handles both concerns in one invocation, supports all file types in use (including \`.mjs\`, \`.ts\`, \`.astro\`), and provides a single \`pnpm run agent\` command agents can run before committing to format, fix, and build in one step.

## Context

- oxlint did not scan \`.mjs\` files when given a directory path, requiring a \`find\`-based workaround in a shell script
- Biome resolves this without workarounds and reduces tooling surface area
- \`.astro\`, \`.github\`, \`.vscode\`, and \`.claude\` directories are excluded from linting and formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated Biome as the new code formatter and linter.
  * Added `pnpm run agent` script to perform formatting, linting, and build in a single step, replacing the previous multi-step workflow.

* **Documentation**
  * Updated documentation formatting for improved readability, including table alignment, spacing adjustments, and content reflowing across multiple guides and reference pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->