### PR TITLE
feat: switch canonical base URL to docs.chinmina.dev

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -67,7 +67,7 @@ const sidebar = [
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://chinmina.github.io",
+  site: "https://docs.chinmina.dev",
   trailingSlash: "never",
 
   integrations: [

--- a/astro.config.test.mjs
+++ b/astro.config.test.mjs
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest"
+import config from "./astro.config.mjs"
+
+describe("astro.config.mjs", () => {
+  it("sets canonical base URL to docs.chinmina.dev", () => {
+    expect(config.site).toBe("https://docs.chinmina.dev")
+  })
+})


### PR DESCRIPTION
## Purpose

Switch the Astro site config canonical base URL from `chinmina.github.io` to `docs.chinmina.dev`, completing the Cloudflare Pages migration (stage 3.1).

## Context

DNS CNAME (`docs.chinmina.dev → chinmina.pages.dev`) is now live. This change completes the canonical URL switch so all pages on both domains emit `<link rel="canonical">` pointing to `https://docs.chinmina.dev`. Coordinating the code merge after DNS is live avoids serving canonicals pointing to an unresolvable domain.

Both the Cloudflare Pages and GitHub Pages builds use the same config, so GitHub Pages will also emit canonicals pointing to the new domain.

## Test plan

- [x] `pnpm run agent` passes (format, lint, vitest, build)
- [x] Built HTML contains `rel="canonical" href="https://docs.chinmina.dev/..."` 
- [ ] After merge: verify `curl -I https://docs.chinmina.dev` returns 200 with valid TLS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site domain configuration.
  * Added configuration verification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->