### PR TITLE
Remove GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy
 
 on:
   push:
@@ -6,10 +6,8 @@ on:
   pull_request:
   workflow_dispatch:
 
-# Allow this job to clone the repo and create a page deployment
 permissions:
   contents: read
-  pages: write
   id-token: write
   deployments: write
   pull-requests: write
@@ -33,10 +31,6 @@ jobs:
         run: pnpm install
       - name: Build site
         run: pnpm run build
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: dist/
       - name: Upload dist artifact
         uses: actions/upload-artifact@v7
         with:
@@ -99,14 +93,3 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: .github/scripts/cloudflare-deploy.sh comment
 
-  deploy:
-    needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Purpose

Completes the migration to Cloudflare Pages as the sole hosting platform. Previous PRs (#32, #33, #34) added Cloudflare deployment, restructured the build pipeline for dual deployment, and switched the canonical URL to docs.chinmina.dev. With Cloudflare live and redirects confirmed working, the GitHub Pages deployment is now redundant.

## Context

- PR #32: restructured build pipeline for dual deployment
- PR #33: added Cloudflare Pages deployment
- PR #34: switched canonical base URL to docs.chinmina.dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified deployment workflow to exclusively use Cloudflare Pages, removing GitHub Pages-specific configuration and deployment steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->