### PR TITLE
Flatten markdown build output for content negotiation

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -4,10 +4,7 @@ import Default from "@astrojs/starlight/components/Head.astro"
 const entry = Astro.locals.starlightRoute?.entry
 let mdUrl: string | null = null
 if (entry != null && Astro.site) {
-  const isIndex = entry.filePath?.endsWith("/index.md") || entry.filePath?.endsWith("/index.mdx")
-  const mdPath = isIndex
-    ? (entry.id ? `/${entry.id}/index.md` : `/index.md`)
-    : `/${entry.id}.md`
+  const mdPath = entry.id ? `/${entry.id}.md` : `/index.md`
   mdUrl = new URL(mdPath, Astro.site).href
 }
 ---

--- a/src/components/SocialIcons.astro
+++ b/src/components/SocialIcons.astro
@@ -5,10 +5,7 @@ import Default from "@astrojs/starlight/components/SocialIcons.astro"
 const entry = Astro.locals.starlightRoute?.entry
 let mdPath: string | null = null
 if (entry != null) {
-  const isIndex = entry.filePath?.endsWith("/index.md") || entry.filePath?.endsWith("/index.mdx")
-  mdPath = isIndex
-    ? (entry.id ? `/${entry.id}/index.md` : `/index.md`)
-    : `/${entry.id}.md`
+  mdPath = entry.id ? `/${entry.id}.md` : `/index.md`
 }
 ---
 

--- a/src/integrations/markdown-pages.mjs
+++ b/src/integrations/markdown-pages.mjs
@@ -50,6 +50,29 @@ function flattenSlugs(items) {
 }
 
 /**
+ * Try to read a source file for the given base path. Tries {base}.mdx,
+ * {base}.md, {base}/index.mdx, {base}/index.md in order.
+ * Returns { content, isMdx } or null if nothing found.
+ */
+export function resolveSourceFile(srcBase) {
+  const candidates = [
+    { path: `${srcBase}.mdx`, isMdx: true },
+    { path: `${srcBase}.md`, isMdx: false },
+    { path: `${srcBase}/index.mdx`, isMdx: true },
+    { path: `${srcBase}/index.md`, isMdx: false },
+  ]
+  for (const { path, isMdx } of candidates) {
+    try {
+      const content = readFileSync(path, "utf8")
+      return { content, isMdx }
+    } catch {
+      // try next candidate
+    }
+  }
+  return null
+}
+
+/**
  * Compute the output path for a source file, flattening index pages.
  * `contributing/index.mdx` → `contributing.md`, `index.mdx` → `index.md`,
  * `getting-started.mdx` → `getting-started.md`.
@@ -165,20 +188,14 @@ export default function markdownPages({
             return next()
           }
 
-          let content, isMdx
-          try {
-            try {
-              content = readFileSync(`${srcBase}.mdx`, "utf8")
-              isMdx = true
-            } catch {
-              content = readFileSync(`${srcBase}.md`, "utf8")
-              isMdx = false
-            }
-          } catch {
+          const resolved = resolveSourceFile(srcBase)
+          if (!resolved) {
             return next()
           }
 
-          const transformed = await transformMarkdown(content, { isMdx })
+          const transformed = await transformMarkdown(resolved.content, {
+            isMdx: resolved.isMdx,
+          })
           res.setHeader("Content-Type", "text/markdown; charset=utf-8")
           res.end(transformed)
         })

--- a/src/integrations/markdown-pages.mjs
+++ b/src/integrations/markdown-pages.mjs
@@ -50,6 +50,15 @@ function flattenSlugs(items) {
 }
 
 /**
+ * Compute the output path for a source file, flattening index pages.
+ * `contributing/index.mdx` → `contributing.md`, `index.mdx` → `index.md`,
+ * `getting-started.mdx` → `getting-started.md`.
+ */
+export function buildOutputPath(file) {
+  return file.replace(/(?:\/index)?\.(mdx|md)$/, ".md")
+}
+
+/**
  * Generate llms.txt content from the sidebar config and page frontmatter cache.
  *
  * @param {object} opts
@@ -60,7 +69,7 @@ function flattenSlugs(items) {
  * @param {string} opts.docsDir  absolute path to src/content/docs
  * @param {Map<string, {title?: string, description?: string}>} pageCache  slug → metadata
  */
-async function generateLlmsTxt({
+export async function generateLlmsTxt({
   siteTitle,
   siteDescription,
   sidebar,
@@ -98,8 +107,7 @@ async function generateLlmsTxt({
       const meta = pageCache.get(slug)
       const title = meta?.title ?? slug
       const description = meta?.description
-      // Index pages live at [slug]/index.md, not [slug].md
-      const mdFile = meta?._isIndex ? `${slug}/index.md` : `${slug}.md`
+      const mdFile = `${slug}.md`
       const url = `${siteUrl}/${mdFile}`
       lines.push(
         description
@@ -202,11 +210,10 @@ export default function markdownPages({
           const fields = frontmatterBlock
             ? parseFrontmatterFields(frontmatterBlock)
             : {}
-          pageCache.set(slug, { ...fields, _isIndex: isIndex })
+          pageCache.set(slug, fields)
 
           const transformed = await transformMarkdown(content, { isMdx })
-          const outRelative = isMdx ? file.replace(/\.mdx$/, ".md") : file
-          const outPath = join(distDir, outRelative)
+          const outPath = join(distDir, buildOutputPath(file))
 
           mkdirSync(dirname(outPath), { recursive: true })
           writeFileSync(outPath, transformed, "utf8")

--- a/src/integrations/markdown-pages.test.mjs
+++ b/src/integrations/markdown-pages.test.mjs
@@ -1,5 +1,11 @@
+import { mkdirSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
 import { describe, expect, it } from "vitest"
-import { buildOutputPath, generateLlmsTxt } from "./markdown-pages.mjs"
+import {
+  buildOutputPath,
+  generateLlmsTxt,
+  resolveSourceFile,
+} from "./markdown-pages.mjs"
 
 describe("generateLlmsTxt", () => {
   it("uses {slug}.md for index pages, not {slug}/index.md", async () => {
@@ -57,6 +63,62 @@ describe("generateLlmsTxt", () => {
     })
 
     expect(result).toContain("https://example.com/index.md")
+  })
+})
+
+describe("resolveSourceFile", () => {
+  const tmpDir = join(
+    import.meta.dirname,
+    "../../node_modules/.cache/test-fixtures",
+  )
+
+  function setup(files) {
+    const dir = join(
+      tmpDir,
+      `fixture-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    for (const file of files) {
+      const path = join(dir, file)
+      mkdirSync(join(path, ".."), { recursive: true })
+      writeFileSync(path, `---\ntitle: test\n---\n# Test`, "utf8")
+    }
+    return dir
+  }
+
+  it("resolves {slug}.mdx directly", () => {
+    const dir = setup(["getting-started.mdx"])
+    const result = resolveSourceFile(join(dir, "getting-started"))
+    expect(result).toEqual({ content: expect.any(String), isMdx: true })
+  })
+
+  it("resolves {slug}.md directly", () => {
+    const dir = setup(["getting-started.md"])
+    const result = resolveSourceFile(join(dir, "getting-started"))
+    expect(result).toEqual({ content: expect.any(String), isMdx: false })
+  })
+
+  it("falls back to {slug}/index.mdx for index pages", () => {
+    const dir = setup(["contributing/index.mdx"])
+    const result = resolveSourceFile(join(dir, "contributing"))
+    expect(result).toEqual({ content: expect.any(String), isMdx: true })
+  })
+
+  it("falls back to {slug}/index.md for index pages", () => {
+    const dir = setup(["contributing/index.md"])
+    const result = resolveSourceFile(join(dir, "contributing"))
+    expect(result).toEqual({ content: expect.any(String), isMdx: false })
+  })
+
+  it("returns null when no source file exists", () => {
+    const dir = setup([])
+    const result = resolveSourceFile(join(dir, "nonexistent"))
+    expect(result).toBeNull()
+  })
+
+  it("prefers {slug}.mdx over {slug}/index.mdx", () => {
+    const dir = setup(["foo.mdx", "foo/index.mdx"])
+    const result = resolveSourceFile(join(dir, "foo"))
+    expect(result).toEqual({ content: expect.any(String), isMdx: true })
   })
 })
 

--- a/src/integrations/markdown-pages.test.mjs
+++ b/src/integrations/markdown-pages.test.mjs
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+import { buildOutputPath, generateLlmsTxt } from "./markdown-pages.mjs"
+
+describe("generateLlmsTxt", () => {
+  it("uses {slug}.md for index pages, not {slug}/index.md", async () => {
+    const pageCache = new Map([
+      [
+        "contributing",
+        {
+          title: "Contributing",
+          description: "How to contribute",
+          _isIndex: true,
+        },
+      ],
+    ])
+
+    const result = await generateLlmsTxt({
+      siteTitle: "Test Site",
+      siteDescription: "A test site",
+      sidebar: [{ label: "Docs", items: ["contributing"] }],
+      siteUrl: "https://example.com",
+      docsDir: "/fake",
+      pageCache,
+    })
+
+    expect(result).toContain("https://example.com/contributing.md")
+    expect(result).not.toContain("contributing/index.md")
+  })
+
+  it("uses {slug}.md for non-index pages", async () => {
+    const pageCache = new Map([
+      ["guides/getting-started", { title: "Getting Started" }],
+    ])
+
+    const result = await generateLlmsTxt({
+      siteTitle: "Test Site",
+      sidebar: [{ label: "Guides", items: ["guides/getting-started"] }],
+      siteUrl: "https://example.com",
+      docsDir: "/fake",
+      pageCache,
+    })
+
+    expect(result).toContain("https://example.com/guides/getting-started.md")
+  })
+
+  it("uses index.md for the root page", async () => {
+    const pageCache = new Map([
+      ["index", { title: "Home", description: "Welcome", _isIndex: false }],
+    ])
+
+    const result = await generateLlmsTxt({
+      siteTitle: "Test Site",
+      sidebar: [{ label: "Home", items: ["index"] }],
+      siteUrl: "https://example.com",
+      docsDir: "/fake",
+      pageCache,
+    })
+
+    expect(result).toContain("https://example.com/index.md")
+  })
+})
+
+describe("buildOutputPath", () => {
+  it("flattens index source pages to {slug}.md", () => {
+    expect(buildOutputPath("contributing/index.mdx")).toBe("contributing.md")
+    expect(buildOutputPath("contributing/index.md")).toBe("contributing.md")
+  })
+
+  it("keeps root index as index.md", () => {
+    expect(buildOutputPath("index.mdx")).toBe("index.md")
+    expect(buildOutputPath("index.md")).toBe("index.md")
+  })
+
+  it("keeps non-index pages as {slug}.md", () => {
+    expect(buildOutputPath("getting-started.mdx")).toBe("getting-started.md")
+    expect(buildOutputPath("guides/setup.md")).toBe("guides/setup.md")
+  })
+})


### PR DESCRIPTION
## Purpose

The docs site generates markdown versions of every page, but the build emits index pages inconsistently — `contributing/index.md` vs `contributing.md` for non-index pages. This inconsistency prevents deterministic URL mapping, which blocks adding HTTP content negotiation via `Accept: text/markdown`.

This flattens all build output to a uniform `{slug}.md` pattern so a future Cloudflare Pages middleware can derive the markdown URL from any request path without special-casing.

## Context

- Part of the [Markdown content negotiation](https://github.com/chinmina/chinmina.github.io/blob/main/docs/prd-markdown-content-negotiation.md) feature (requirements R7–R11)
- The Cloudflare Pages middleware (R1–R6, R12) depends on this uniform URL pattern and will follow in a separate PR
- Source file structure is unchanged — Astro requires `index.mdx` for section landing pages, so only the dist output and URL references change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utilities to resolve source markdown files and normalize output paths.

* **Bug Fixes**
  * Consistently generate .md alternate links for both index and non-index pages (applies to site header and social link export).

* **Tests**
  * Added tests validating file resolution, output path mapping, and generated URL formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->