### PR TITLE
feat: add middleware for `Accept: text/markdown` content negotiation

### DIFF
--- a/functions/_middleware.test.ts
+++ b/functions/_middleware.test.ts
@@ -55,7 +55,7 @@ describe("markdown content negotiation middleware", () => {
       headers: { Accept: "text/markdown" },
     })
 
-    const _response = await onRequest(context)
+    await onRequest(context)
 
     expect(context.next).toHaveBeenCalled()
   })
@@ -65,7 +65,7 @@ describe("markdown content negotiation middleware", () => {
       headers: { Accept: "text/markdown" },
     })
 
-    const _response = await onRequest(context)
+    await onRequest(context)
 
     expect(context.next).toHaveBeenCalled()
   })
@@ -110,7 +110,7 @@ describe("markdown content negotiation middleware", () => {
   it("passes through when no Accept header is present", async () => {
     const context = createContext("https://example.com/contributing")
 
-    const _response = await onRequest(context)
+    await onRequest(context)
 
     expect(context.next).toHaveBeenCalled()
   })

--- a/functions/_middleware.test.ts
+++ b/functions/_middleware.test.ts
@@ -107,6 +107,27 @@ describe("markdown content negotiation middleware", () => {
     expect(response.headers.get("Location")).toBe("/contributing.md?ref=footer")
   })
 
+  it("strips trailing slash before redirecting", async () => {
+    const context = createContext("https://example.com/contributing/", {
+      headers: { Accept: "text/markdown" },
+    })
+
+    const response = await onRequest(context)
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get("Location")).toBe("/contributing.md")
+  })
+
+  it("passes through when URL with trailing slash has a file extension", async () => {
+    const context = createContext("https://example.com/styles/main.css/", {
+      headers: { Accept: "text/markdown" },
+    })
+
+    await onRequest(context)
+
+    expect(context.next).toHaveBeenCalled()
+  })
+
   it("passes through when no Accept header is present", async () => {
     const context = createContext("https://example.com/contributing")
 

--- a/functions/_middleware.test.ts
+++ b/functions/_middleware.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest"
+import { onRequest } from "./_middleware"
+
+function createContext(
+  url: string,
+  options: { method?: string; headers?: Record<string, string> } = {},
+) {
+  const request = new Request(url, {
+    method: options.method ?? "GET",
+    headers: options.headers ?? {},
+  })
+  const next = vi.fn(() => Promise.resolve(new Response("original")))
+  return { request, next }
+}
+
+describe("markdown content negotiation middleware", () => {
+  it("redirects GET with Accept: text/markdown to {path}.md", async () => {
+    const context = createContext("https://example.com/contributing", {
+      headers: { Accept: "text/markdown" },
+    })
+
+    const response = await onRequest(context)
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get("Location")).toBe("/contributing.md")
+    expect(context.next).not.toHaveBeenCalled()
+  })
+
+  it("redirects GET on root path to /index.md", async () => {
+    const context = createContext("https://example.com/", {
+      headers: { Accept: "text/markdown" },
+    })
+
+    const response = await onRequest(context)
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get("Location")).toBe("/index.md")
+    expect(context.next).not.toHaveBeenCalled()
+  })
+
+  it("passes through when Accept does not include text/markdown", async () => {
+    const context = createContext("https://example.com/contributing", {
+      headers: { Accept: "text/html" },
+    })
+
+    const response = await onRequest(context)
+
+    expect(context.next).toHaveBeenCalled()
+    expect(response).toBe(await context.next.mock.results[0].value)
+  })
+
+  it("passes through for non-GET/HEAD methods", async () => {
+    const context = createContext("https://example.com/contributing", {
+      method: "POST",
+      headers: { Accept: "text/markdown" },
+    })
+
+    const _response = await onRequest(context)
+
+    expect(context.next).toHaveBeenCalled()
+  })
+
+  it("passes through when URL path has a file extension", async () => {
+    const context = createContext("https://example.com/styles/main.css", {
+      headers: { Accept: "text/markdown" },
+    })
+
+    const _response = await onRequest(context)
+
+    expect(context.next).toHaveBeenCalled()
+  })
+
+  it("redirects HEAD with Accept: text/markdown", async () => {
+    const context = createContext("https://example.com/contributing", {
+      method: "HEAD",
+      headers: { Accept: "text/markdown" },
+    })
+
+    const response = await onRequest(context)
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get("Location")).toBe("/contributing.md")
+  })
+
+  it("redirects when Accept contains text/markdown among other types", async () => {
+    const context = createContext("https://example.com/contributing", {
+      headers: { Accept: "text/markdown, text/html;q=0.9" },
+    })
+
+    const response = await onRequest(context)
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get("Location")).toBe("/contributing.md")
+  })
+
+  it("preserves query string in redirect URL", async () => {
+    const context = createContext(
+      "https://example.com/contributing?ref=footer",
+      {
+        headers: { Accept: "text/markdown" },
+      },
+    )
+
+    const response = await onRequest(context)
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get("Location")).toBe("/contributing.md?ref=footer")
+  })
+
+  it("passes through when no Accept header is present", async () => {
+    const context = createContext("https://example.com/contributing")
+
+    const _response = await onRequest(context)
+
+    expect(context.next).toHaveBeenCalled()
+  })
+})

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -10,20 +10,36 @@ export async function onRequest(context: Context): Promise<Response> {
     return context.next()
   }
 
-  const url = new URL(request.url)
-  const lastSegment = url.pathname.split("/").pop() ?? ""
-  if (lastSegment.includes(".")) {
-    return context.next()
-  }
-
   const accept = request.headers.get("Accept") ?? ""
   if (!accept.includes("text/markdown")) {
     return context.next()
   }
 
-  const path = url.pathname === "/" ? "/index" : url.pathname
+  const url = new URL(request.url)
+  const pathname = cutSuffix(url.pathname, "/")
+  const lastSegment = cutEnd(pathname, "/")
+  if (lastSegment.includes(".")) {
+    return context.next()
+  }
+
+  const path = pathname === "" ? "/index" : pathname
   return new Response(null, {
     status: 302,
     headers: { Location: `${path}.md${url.search}` },
   })
+}
+
+function cutSuffix(path: string, suffix: string): string {
+  if (path.endsWith(suffix)) {
+    return path.slice(0, -suffix.length)
+  }
+  return path
+}
+
+function cutEnd(str: string, sep: string): string {
+  const index = str.lastIndexOf(sep)
+  if (index === -1) {
+    return str
+  }
+  return str.slice(index)
 }

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,0 +1,29 @@
+interface Context {
+  request: Request
+  next: () => Promise<Response>
+}
+
+export async function onRequest(context: Context): Promise<Response> {
+  const { request } = context
+  const method = request.method
+  if (method !== "GET" && method !== "HEAD") {
+    return context.next()
+  }
+
+  const url = new URL(request.url)
+  const lastSegment = url.pathname.split("/").pop() ?? ""
+  if (lastSegment.includes(".")) {
+    return context.next()
+  }
+
+  const accept = request.headers.get("Accept") ?? ""
+  if (!accept.includes("text/markdown")) {
+    return context.next()
+  }
+
+  const path = url.pathname === "/" ? "/index" : url.pathname
+  return new Response(null, {
+    status: 302,
+    headers: { Location: `${path}.md${url.search}` },
+  })
+}


### PR DESCRIPTION
## Purpose

Completes HTTP content negotiation support for markdown content, building on the flattened markdown output from #36. Clients can now request documentation as raw markdown using the standard `Accept: text/markdown` header rather than needing to know the site's `.md` URL convention. This supports LLM tooling and programmatic consumers that prefer markdown over HTML.

## Context

- Implements requirements R1-R6 and R12 from the [content negotiation PRD](https://github.com/chinmina/chinmina.github.io/blob/main/docs/prd-markdown-content-negotiation.md)
- Depends on #36 which flattened build output to the uniform `{slug}.md` pattern that makes the redirect URL deterministic
- The middleware is a Cloudflare Pages Function (`functions/_middleware.ts`) — no Astro adapter or SSR needed, the site stays fully static

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Requests with an Accept header including text/markdown (GET/HEAD) are redirected (302) to the corresponding .md URL; root (/) maps to /index.md and query strings are preserved.
  * Requests are passed through unchanged when method isn't GET/HEAD, when the path already references a file, or when markdown isn't requested.

* **Tests**
  * Added tests validating markdown content-negotiation, redirect targets, query preservation, and pass-through cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->