### PR TITLE
docs: document dynamic repository scoping and base-path configuration

### DIFF
--- a/src/content/docs/reference/api/organization-git-credentials.md
+++ b/src/content/docs/reference/api/organization-git-credentials.md
@@ -14,7 +14,7 @@ when vending GitHub tokens. Profiles allow configuring different sets of
 repositories and permissions for different use cases.
 
 This endpoint serves the same underlying function as [POST
-/organization/token/{profile}](./organization-token) (vending GitHub installation
+/organization/token/{profile}](/reference/api/organization-token) (vending GitHub installation
 tokens), however its request and response format follows Git's [credential
 helper protocol][helper-protocol]. This allows Chinmina Bridge to act as a Git
 credential helper, enabling transparent authentication for Git operations
@@ -31,9 +31,9 @@ handling.
 
 ### See also
 
-- [Buildkite integration guide](../../guides/buildkite-integration) for details
+- [Buildkite integration guide](/guides/buildkite-integration) for details
   on how this endpoint is used in practice.
-- [Customizing token permissions guide](../../guides/customizing-permissions) for
+- [Customizing token permissions guide](/guides/customizing-permissions) for
   practical setup and usage instructions.
 
 ## Request format
@@ -58,6 +58,14 @@ Examples:
 - `POST /organization/git-credentials/buildkite-plugin`
 
 The API does not use prefixes. Prefixes like `org:` are part of the plugin interface only and are translated by the plugins to the appropriate API paths.
+
+### Repository scope
+
+For profiles configured with `repositories: ["{{caller-scoped-repository}}"]`
+(see [caller-scoped repositories](/reference/profiles/organization#caller-scoped-repositories)),
+the target repository is derived automatically from the `path` field in the
+request body — no extra parameter is needed. If the body doesn't resolve to a
+repository, the request returns `400 Bad Request`.
 
 ### Request body
 
@@ -85,18 +93,18 @@ The response body is plain text with newline-separated key-value pairs. Git pars
 
 ### Empty response (200 OK)
 
-When the requested repository is not in the profile's allowed repository list, the endpoint returns a successful but empty response. See [Git credentials format](../git-credentials-format#empty-response) for details. This allows Git credential helpers to fall through to other credential sources.
+When the requested repository is not in the profile's allowed repository list, the endpoint returns a successful but empty response. See [Git credentials format](/reference/git-credentials-format#empty-response) for details. This allows Git credential helpers to fall through to other credential sources.
 
 ### Error responses
 
-| Status code               | Condition                               | Response body      |
-| ------------------------- | --------------------------------------- | ------------------ |
-| 400 Bad Request           | Invalid profile format or parameter     | JSON error message |
+| Status code               | Condition                                                              | Response body      |
+| -------------------------- | ----------------------------------------------------------------------- | ------------------- |
+| 400 Bad Request           | Invalid profile format or parameter, or caller-scoped repository could not be resolved | JSON error message |
 | 401 Unauthorized          | Missing or invalid JWT                  | JSON error message |
-| 403 Forbidden             | JWT valid but claims insufficient       | JSON error message |
+| 403 Forbidden             | JWT valid but claims insufficient, or GitHub rejected a caller-scoped repository | JSON error message |
 | 404 Not Found             | Profile does not exist                  | JSON error message |
 | 500 Internal Server Error | Token vending failure, GitHub API error | JSON error message |
 
 Error responses are returned in JSON format. Any response that Git does not recognize as valid for the format is regarded as an error and discarded.
 
-[helper-protocol]: ../git-credentials-format
+[helper-protocol]: /reference/git-credentials-format

--- a/src/content/docs/reference/api/organization-token.md
+++ b/src/content/docs/reference/api/organization-token.md
@@ -17,9 +17,9 @@ making direct API calls, or want more flexible response handling.
 
 ### See also
 
-- [Buildkite integration guide](../../guides/buildkite-integration) for details
+- [Buildkite integration guide](/guides/buildkite-integration) for details
   on how this endpoint is used in practice.
-- [Customizing token permissions guide](../../guides/customizing-permissions) for
+- [Customizing token permissions guide](/guides/customizing-permissions) for
   practical setup and usage instructions.
 
 ## Purpose
@@ -50,6 +50,19 @@ Examples:
 - `POST /organization/token/buildkite-plugin`
 
 The API does not use prefixes. Prefixes like `org:` are part of the plugin interface only and are translated by the plugins to the appropriate API paths.
+
+### Repository scope parameter
+
+For profiles configured with `repositories: ["{{caller-scoped-repository}}"]`
+(see [caller-scoped repositories](/reference/profiles/organization#caller-scoped-repositories)),
+the target repository is supplied via the `repository-scope` query parameter:
+
+```text
+POST /organization/token/agent-pr?repository-scope=widget
+```
+
+Supplying `repository-scope` for a profile that is not caller-scoped, or
+omitting it for one that is, returns `400 Bad Request`.
 
 ### Request body
 
@@ -91,12 +104,12 @@ When the requested repository is not in the profile's repository list, the endpo
 
 ## Error responses
 
-| Status code      | Condition                     | Response   |
-| ---------------- | ----------------------------- | ---------- |
-| 400 Bad Request  | Invalid profile format        | JSON error |
-| 401 Unauthorized | Missing or invalid JWT        | JSON error |
-| 403 Forbidden    | Insufficient JWT claims       | JSON error |
-| 404 Not Found    | Profile does not exist        | JSON error |
-| 500 Server Error | Token vending or GitHub error | JSON error |
+| Status code      | Condition                                                                 | Response   |
+| ---------------- | -------------------------------------------------------------------------- | ---------- |
+| 400 Bad Request  | Invalid profile format, or repository-scope missing/unexpected/malformed | JSON error |
+| 401 Unauthorized | Missing or invalid JWT                                                    | JSON error |
+| 403 Forbidden    | Insufficient JWT claims, or GitHub rejected a caller-scoped repository   | JSON error |
+| 404 Not Found    | Profile does not exist                                                    | JSON error |
+| 500 Server Error | Token vending or GitHub error                                             | JSON error |
 
 [gh-audit-token]: https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/identifying-audit-log-events-performed-by-an-access-token

--- a/src/content/docs/reference/configuration.md
+++ b/src/content/docs/reference/configuration.md
@@ -42,9 +42,13 @@ number is somewhat higher than might otherwise be usual.
 
 An optional path prefix (e.g. `/api/v1`) to serve all routes under, for
 deployments that sit behind a reverse proxy which forwards the full
-original path rather than rewriting it. Must start with `/`, must not end
-with `/`, and must not contain `//`; the server fails to start on an
-invalid value.
+original path rather than rewriting it.
+
+The value is normalised on startup. Surrounding whitespace is trimmed, a
+leading `/` is added when missing, and trailing slashes are removed. A value
+that normalises to empty, such as `/` or `///`, means no prefix is applied.
+The server fails to start only when `//` remains after normalisation, as in
+`//api` or `/api//v1`.
 
 A request path that does not start with the configured prefix (matched on a
 segment boundary, so `SERVER_BASE_PATH=/api` does not match `/apiary`)

--- a/src/content/docs/reference/configuration.md
+++ b/src/content/docs/reference/configuration.md
@@ -38,6 +38,18 @@ For outgoing HTTPS requests, the maximum connections that may be made per host.
 Given that Chinmina mainly targets Buildkite and GitHub API endpoints, this
 number is somewhat higher than might otherwise be usual.
 
+###### `SERVER_BASE_PATH`
+
+An optional path prefix (e.g. `/api/v1`) to serve all routes under, for
+deployments that sit behind a reverse proxy which forwards the full
+original path rather than rewriting it. Must start with `/`, must not end
+with `/`, and must not contain `//`; the server fails to start on an
+invalid value.
+
+A request path that does not start with the configured prefix (matched on a
+segment boundary, so `SERVER_BASE_PATH=/api` does not match `/apiary`)
+returns `404 Not Found`.
+
 ## Cache
 
 Chinmina caches GitHub access tokens to reduce API calls. By default, tokens are
@@ -220,7 +232,7 @@ supplied the `read_pipelines` scope.
 
 Either `GITHUB_APP_PRIVATE_KEY` or `GITHUB_APP_PRIVATE_KEY_ARN` is required.
 
-`GITHUB_APP_PRIVATE_KEY_ARN` is strongly recommended where possible (see [KMS configuration](../../guides/kms)).
+`GITHUB_APP_PRIVATE_KEY_ARN` is strongly recommended where possible (see [KMS configuration](/guides/kms)).
 
 :::
 
@@ -232,7 +244,7 @@ The GitHub Application private key in PEM format, supplied as text (not a file p
 
 The AWS KMS key (or alias) resource ARN that has been configured for use by Chinmina.
 
-See the [AWS KMS setup and configuration](../../guides/kms) guide for more details.
+See the [AWS KMS setup and configuration](/guides/kms) guide for more details.
 
 ###### `GITHUB_APP_ID` :badge[required]
 
@@ -363,7 +375,7 @@ variables available.
 :::
 
 [otel-exporter-config]: https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options
-[profiles-config]: profiles/
-[pipeline-profile-config]: profiles/pipeline
-[org-profile-config]: profiles/organization
+[profiles-config]: /reference/profiles
+[pipeline-profile-config]: /reference/profiles/pipeline
+[org-profile-config]: /reference/profiles/organization
 [pyroscope]: https://grafana.com/oss/pyroscope/

--- a/src/content/docs/reference/profiles/organization.md
+++ b/src/content/docs/reference/profiles/organization.md
@@ -5,7 +5,7 @@ description: Details of what an organization profile is and how it is used.
 
 An organization profile defines sets of repository access and permissions available to agents associated with the Buildkite organization, optionally restricted to specific pipelines via match rules.
 
-The location of the profile configuration file is specified via the [`GITHUB_ORG_PROFILE`](../configuration#github_org_profile) environment variable.
+The location of the profile configuration file is specified via the [`GITHUB_ORG_PROFILE`](/reference/configuration#github_org_profile) environment variable.
 
 Profile-related tokens are requested via separate URL paths. Tokens will not be vended on these paths unless configuration is present.
 
@@ -59,7 +59,7 @@ _(optional)_
 
 Claim matching rules that restrict which pipelines can use this profile. Omit this field entirely to make the profile available to all pipelines.
 
-See the [profile matching reference](matching) for complete details on:
+See the [profile matching reference](/reference/profiles/matching) for complete details on:
 
 - Match rule syntax (exact vs regex matching)
 - Available claims
@@ -68,11 +68,30 @@ See the [profile matching reference](matching) for complete details on:
 
 ###### `repositories`
 
-A list of repositories that the profile has access to. This list includes only the repository name and does not include the owner or organization name.
+The repositories the profile grants access to. One of:
+
+- A list of repository names (owner/organization omitted), e.g. `["release-tools", "shared-infra"]`
+- `{{all-repositories}}`, granting access to every repository the GitHub App
+  installation can reach.
+- `{{caller-scoped-repository}}`, narrowing the token to a single repository
+  named by the caller at request time (see [caller-scoped
+  repositories](#caller-scoped-repositories) below)
+
+A literal (`{{all-repositories}}`, `{{caller-scoped-repository}}`, or `*`)
+must be the only entry in the list; it cannot be combined with named
+repositories.
+
+::::caution[Deprecated `*` wildcard]
+
+The bare `*` wildcard is a deprecated alias for `{{all-repositories}}`. It
+still works and emits a startup warning; it will be removed in the future v1
+release. Migrate existing profiles to `{{all-repositories}}`.
+
+::::
 
 ###### `permissions`
 
-A list of permissions granted to the profile. The `metadata:read` permission is [automatically included](../profiles#automatic-permissions) in all tokens. See the [GitHub documentation for tokens][github-token-permissions] for available permission values.
+A list of permissions granted to the profile. The `metadata:read` permission is [automatically included](/reference/profiles#automatic-permissions) in all tokens. See the [GitHub documentation for tokens][github-token-permissions] for available permission values.
 
 ### Example
 
@@ -89,9 +108,13 @@ organization:
 
     # allow package access to any repository
     - name: "package-registry"
-      # '*' indicates all, when specified must be only value. No other wildcards supported.
-      repositories: ["*"]
+      repositories: ["{{all-repositories}}"]
       permissions: ["packages:read"]
+
+    # let a shared CI pipeline open PRs against any repository it names
+    - name: "agent-pr"
+      repositories: ["{{caller-scoped-repository}}"]
+      permissions: ["contents:write", "pull_requests:write"]
 
     # allow write access only for release pipelines on main branch
     - name: "release-publisher"
@@ -127,9 +150,43 @@ environment:
 
 The plugins translate these to appropriate API paths (`/organization/token/package-registry`, etc.).
 
+## Caller-scoped repositories
+
+A profile with `repositories: ["{{caller-scoped-repository}}"]` does not
+store a fixed repository list. Instead, the caller names a single target
+repository per request, and the vended token is narrowed to it — useful for
+workflows (e.g. AI coding agents) that operate against a different
+repository each run without needing one profile per repository.
+
+**`/organization/token/{profile}`** takes the target repository via the
+`repository-scope` query parameter:
+
+```text
+POST /organization/token/agent-pr?repository-scope=widget
+```
+
+**`/organization/git-credentials/{profile}`** derives the target repository
+from the Git remote URL in the request body, with no extra parameter
+required.
+
+Validation is strict and bidirectional:
+
+- Supplying `repository-scope` to a profile that isn't caller-scoped returns
+  `400 Bad Request`.
+- Omitting `repository-scope` (and, for `/organization/token`, having no
+  resolvable repository) on a caller-scoped profile returns `400 Bad
+Request`.
+- A scope value containing `/`, whitespace, or control characters returns
+  `400 Bad Request`; it is otherwise used verbatim (not normalized) as the
+  repository name and cache key.
+- If GitHub rejects the resulting token request — for example, the named
+  repository doesn't exist or isn't in the installation — the response is a
+  generic `403 Forbidden`, never a `404`, so the response never reveals
+  whether a repository exists.
+
 ## See also
 
-For permissions scoped to the pipeline's own repository, see [pipeline profiles](pipeline).
+For permissions scoped to the pipeline's own repository, see [pipeline profiles](/reference/profiles/pipeline).
 
 [github-token-permissions]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
 [chinmina-token]: https://github.com/chinmina/chinmina-token-buildkite-plugin


### PR DESCRIPTION
## Purpose

Closes a documentation gap left by two released features that shipped without reference coverage: dynamic repository scoping for organization profiles (v0.11.0) and the `SERVER_BASE_PATH` sub-path deployment option (v0.10.0). Operators configuring caller-scoped profiles or reverse-proxy deployments had no reference to work from and had to read the chinmina-bridge source to find the `{{caller-scoped-repository}}`/`{{all-repositories}}` YAML literals, the `repository-scope` query parameter, or the base-path env var.

## Context

Identified while auditing chinmina-bridge releases since January for undocumented user-facing changes. Source of truth is the chinmina-bridge repo (PRs #297 and #287) and the built binary's own validation logic (`internal/profile/repositoryscope.go`, `internal/config/basepath.go`), read directly to confirm exact literal strings, query-parameter names, and error status codes documented here.