### PR TITLE
docs: fix broken links and include link linter

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import starlight from "@astrojs/starlight"
 import { defineConfig } from "astro/config"
 import d2 from "astro-d2"
 import starlightHeadingBadges from "starlight-heading-badges"
+import starlightLinksValidator from "starlight-links-validator"
 import markdownPages from "./src/integrations/markdown-pages.mjs"
 
 const sidebar = [
@@ -77,7 +78,7 @@ export default defineConfig({
 
   integrations: [
     starlight({
-      plugins: [starlightHeadingBadges()],
+      plugins: [starlightHeadingBadges(), starlightLinksValidator()],
 
       title: "Chinmina",
       logo: { src: "/src/assets/chinmina-logo-white.png", alt: "Chinmina" },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "astro-d2": "^0.13.1",
     "sharp": "^0.35.3",
     "starlight-heading-badges": "^0.8.0",
+    "starlight-links-validator": "^0.25.3",
     "typescript": "^6.0.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       starlight-heading-badges:
         specifier: ^0.8.0
         version: 0.8.0(@astrojs/starlight@0.41.7(@astrojs/markdown-remark@7.2.2)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.1)(yaml@2.9.0))(typescript@6.0.3))
+      starlight-links-validator:
+        specifier: ^0.25.3
+        version: 0.25.3(@astrojs/starlight@0.41.7(@astrojs/markdown-remark@7.2.2)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.1)(yaml@2.9.0))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1385,6 +1388,9 @@ packages:
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
+  '@types/picomatch@4.0.3':
+    resolution: {integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==}
+
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
@@ -1481,6 +1487,10 @@ packages:
   am-i-vibing@0.4.0:
     resolution: {integrity: sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==}
     hasBin: true
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
 
   ansi-regex@6.3.0:
     resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
@@ -1742,6 +1752,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
@@ -1863,6 +1877,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-flag@5.0.1:
+    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
+    engines: {node: '>=12'}
+
   hast-util-embedded@3.0.0:
     resolution: {integrity: sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==}
 
@@ -1948,6 +1966,10 @@ packages:
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
+
+  is-absolute-url@5.0.0:
+    resolution: {integrity: sha512-sdJyNpBnQHuVnBunfzjAecOhZr2+A30ywfFvu3EnxtKLUWfwGgyWUmqHbGZiU6vTfHpCPm5GvLe4BAvlU9n8VQ==}
+    engines: {node: '>=20'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -2592,6 +2614,13 @@ packages:
     peerDependencies:
       '@astrojs/starlight': '>=0.41.0'
 
+  starlight-links-validator@0.25.3:
+    resolution: {integrity: sha512-kNE2F8fwdq7r8l6Zx2nH3SDnLlVu2VRmbmyV/nSpbtWzf9+S81H2VBZ6GRevIKbm8qOoYSZvXzNATT8ZXw9bmw==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.41.0'
+      astro: '>=7.0.2'
+
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
@@ -2627,10 +2656,18 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-hyperlinks@4.5.0:
+    resolution: {integrity: sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==}
+    engines: {node: '>=20'}
+
   svgo@4.0.2:
     resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
     engines: {node: '>=16'}
     hasBin: true
+
+  terminal-link@5.0.0:
+    resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
+    engines: {node: '>=20'}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -4169,6 +4206,8 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/picomatch@4.0.3': {}
+
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 24.10.1
@@ -4294,6 +4333,10 @@ snapshots:
   am-i-vibing@0.4.0:
     dependencies:
       process-ancestry: 0.1.0
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
 
   ansi-regex@6.3.0: {}
 
@@ -4591,6 +4634,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  environment@1.1.0: {}
+
   error-stack-parser-es@1.0.5: {}
 
   es-module-lexer@2.0.0: {}
@@ -4771,6 +4816,8 @@ snapshots:
       uncrypto: 0.1.3
 
   has-flag@4.0.0: {}
+
+  has-flag@5.0.1: {}
 
   hast-util-embedded@3.0.0:
     dependencies:
@@ -4976,6 +5023,8 @@ snapshots:
   inline-style-parser@0.2.7: {}
 
   iron-webcrypto@1.2.1: {}
+
+  is-absolute-url@5.0.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -6055,6 +6104,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  starlight-links-validator@0.25.3(@astrojs/starlight@0.41.7(@astrojs/markdown-remark@7.2.2)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.1)(yaml@2.9.0)):
+    dependencies:
+      '@astrojs/markdown-satteri': 0.3.5
+      '@astrojs/starlight': 0.41.7(@astrojs/markdown-remark@7.2.2)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.1)(yaml@2.9.0))(typescript@6.0.3)
+      '@types/picomatch': 4.0.3
+      astro: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.1)(yaml@2.9.0)
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      is-absolute-url: 5.0.0
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-to-hast: 13.2.1
+      picomatch: 4.0.5
+      satteri: 0.9.5
+      terminal-link: 5.0.0
+      unist-util-visit: 5.1.0
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - supports-color
+
   std-env@4.2.0: {}
 
   stream-replace-string@2.0.0: {}
@@ -6093,6 +6161,11 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@4.5.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
+
   svgo@4.0.2:
     dependencies:
       commander: 11.1.0
@@ -6102,6 +6175,11 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.6.1
+
+  terminal-link@5.0.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      supports-hyperlinks: 4.5.0
 
   tiny-inflate@1.0.3: {}
 

--- a/src/content/docs/contributing/development.mdx
+++ b/src/content/docs/contributing/development.mdx
@@ -17,9 +17,9 @@ executable directly, but this tends to make running the server more difficult.
 
 Required tools:
 
-2. [`direnv`](https://direnv.net/) for local environment configuration
-3. Docker (`docker compose`) to run the server on the local machine.
-4. Go language and toolchain.
+1. [`direnv`](https://direnv.net/) for local environment configuration
+2. Docker (`docker compose`) to run the server on the local machine.
+3. Go language and toolchain.
 
 <Aside type="tip">
 
@@ -34,7 +34,7 @@ other projects.
 
 ## Setting up GitHub and Buildkite
 
-Refer to the ["Getting Started" guide's](../guides/getting-started) sections on
+Refer to the ["Getting Started" guide's](/guides/getting-started) sections on
 Buildkite and GitHub for the creation of the Buildkite API key and the GitHub
 application.
 
@@ -61,7 +61,7 @@ Used in testing only. These comma-separated, key-value pairs should be provided 
    override any defaults set in `.envrc`.
 
 2. Using the "Getting started" guide's [essential
-   configuration](getting-started#chinmina-bridge-setup) section, fill in the
+   configuration](/guides/getting-started#chinmina-bridge-setup) section, fill in the
    suggested values in `.envrc.local`.
 
 3. Run `direnv allow` to bring the updated configuration into the environment.

--- a/src/content/docs/contributing/index.mdx
+++ b/src/content/docs/contributing/index.mdx
@@ -17,7 +17,7 @@ appreciated.
    issues](https://github.com/chinmina/chinmina-bridge/issues) for ideas, or
    open a new issue to discuss your proposed changes.
 2. **Set up your environment**: Follow the [local development
-   guide](./development) to get your development environment ready.
+   guide](/contributing/development) to get your development environment ready.
 3. **Make your changes**: Write focused, well-tested code that follows the
    project's conventions.
 4. **Submit a pull request**: Open a PR with a clear description of the changes
@@ -102,6 +102,6 @@ project quality.
 
 ## Additional Resources
 
-- [Local development setup](./development)
-- [Release process](./releases)
+- [Local development setup](/contributing/development)
+- [Release process](/contributing/releases)
 - [Project documentation](https://chinmina.github.io)

--- a/src/content/docs/guides/customizing-permissions.mdx
+++ b/src/content/docs/guides/customizing-permissions.mdx
@@ -55,7 +55,7 @@ Organization profiles provide controlled access to a static list of repositories
    ```
 
    :::note
-   The `metadata:read` permission is [automatically included](../reference/profiles#automatic-permissions) in all tokens. You do not need to specify it in your configuration.
+   The `metadata:read` permission is [automatically included](/reference/profiles#automatic-permissions) in all tokens. You do not need to specify it in your configuration.
    :::
 
 2. Configure Chinmina Bridge
@@ -163,7 +163,7 @@ Pipelines on other branches will receive a 403 error when requesting this profil
 
 ## Next steps
 
-See the [profile reference](../reference/profiles) for:
+See the [profile reference](/reference/profiles) for:
 
 - Complete field definitions
 - Match rule syntax and patterns

--- a/src/content/docs/guides/distributed-cache.mdx
+++ b/src/content/docs/guides/distributed-cache.mdx
@@ -111,7 +111,7 @@ When IAM authentication is enabled, TLS is forced on regardless of the
 Chinmina uses the standard AWS SDK credential chain for IAM authentication.
 Credentials are typically supplied via IMDS (instance metadata service) or the
 container credential provider, consistent with the approach described in the
-[KMS guide](../kms).
+[KMS guide](/guides/kms).
 
 </Aside>
 

--- a/src/content/docs/guides/getting-started.mdx
+++ b/src/content/docs/guides/getting-started.mdx
@@ -77,7 +77,7 @@ Create an API key with access to the REST API **only** with access to the
 
 For a production installation on AWS it is strongly recommended that you upload
 your private key to KMS, as documented in [Protecting the GitHub private key
-](./kms)
+](/guides/kms)
 
 </Aside>
 
@@ -113,7 +113,7 @@ export function ConfigRef({ name, default: defaultValue }) {
 
 
 A minimal configuration of the service requires at least the configuration
-below. See the [Configuration](../reference/configuration) reference for details of all
+below. See the [Configuration](/reference/configuration) reference for details of all
 configuration.
 
 - <ConfigRef name="JWT_BUILDKITE_ORGANIZATION_SLUG" />
@@ -135,7 +135,7 @@ configuration.
 - **Either**:
   - <ConfigRef name="GITHUB_APP_PRIVATE_KEY_ARN" />
 
-    It is **strongly** recommended to [store the private key in AWS KMS](./kms)
+    It is **strongly** recommended to [store the private key in AWS KMS](/guides/kms)
     and provide the ARN of the key here. This will allow Chinmina to sign tokens
     but protects the key from extraction and misuse.
 
@@ -154,5 +154,5 @@ configuration.
   The installation ID of the created GitHub application into your organization.
 
 The service will start (by default) on port 8080, but this is
-[configurable](../../reference/configuration#server_port) if necessary.
+[configurable](/reference/configuration#server_port) if necessary.
 Generally speaking, this is best handled via container port mapping.

--- a/src/content/docs/guides/observability.md
+++ b/src/content/docs/guides/observability.md
@@ -5,7 +5,7 @@ description: Using OpenTelemetry and logging to understand and diagnose Chinmina
 
 Chinmina produces traces and metrics via OpenTelemetry, and logs to stdout in JSON format.
 
-For audit log details, see the [auditing reference](../reference/auditing). For complete telemetry technical details, see the [telemetry reference](../reference/telemetry).
+For audit log details, see the [auditing reference](/reference/auditing). For complete telemetry technical details, see the [telemetry reference](/reference/telemetry).
 
 ## Enabling OpenTelemetry
 
@@ -42,7 +42,7 @@ OBSERVE_ENABLED=true
 OBSERVE_TYPE=stdout
 ```
 
-See the [configuration reference](../reference/configuration) for all `OBSERVE_*` variables, including collector settings, batch timeouts, and metric read intervals.
+See the [configuration reference](/reference/configuration) for all `OBSERVE_*` variables, including collector settings, batch timeouts, and metric read intervals.
 
 ## Critical user journeys
 
@@ -184,7 +184,7 @@ Internal span: refresh_organization_profile
 - Consolidate repository access patterns
 - Review profile match conditions
 - Consider organizational endpoint usage
-- Enable the [distributed cache](./distributed-cache) to share tokens across replicas
+- Enable the [distributed cache](/guides/distributed-cache) to share tokens across replicas
 
 ### Cache encryption errors
 
@@ -203,7 +203,7 @@ Internal span: refresh_organization_profile
 **Remediation:**
 
 - Prefix errors during encryption rollout are expected — unencrypted entries resolve as cached tokens expire (within 15 minutes)
-- Decryption failures after key rotation: verify the rotation procedure in the [distributed cache guide](./distributed-cache) and confirm the old primary key was not disabled before cached tokens expired
+- Decryption failures after key rotation: verify the rotation procedure in the [distributed cache guide](/guides/distributed-cache) and confirm the old primary key was not disabled before cached tokens expired
 - Keyset refresh warnings: verify IAM permissions for Secrets Manager and KMS, then check service health
 - Persistent errors with no configuration changes: check Valkey connectivity and data integrity
 
@@ -229,6 +229,6 @@ OBSERVE_PYROSCOPE_BASIC_AUTH_USER=123456
 OBSERVE_PYROSCOPE_BASIC_AUTH_PASSWORD=glc_...
 ```
 
-See the [configuration reference](../reference/configuration#pyroscope-continuous-profiling) for all `OBSERVE_PYROSCOPE_*` variables.
+See the [configuration reference](/reference/configuration#pyroscope-continuous-profiling) for all `OBSERVE_PYROSCOPE_*` variables.
 
 [pyroscope]: https://grafana.com/oss/pyroscope/

--- a/src/content/docs/guides/verifying-releases.md
+++ b/src/content/docs/guides/verifying-releases.md
@@ -3,7 +3,7 @@ title: Verifying a release binary
 description: Verify Chinmina release binaries with cosign
 ---
 
-Releases [are signed](./releases.md) with `cosign` as part of the release
+Releases [are signed](/contributing/releases) with `cosign` as part of the release
 process. The build produces additional attestation bundles during this process,
 which can be used to verify both binaries and Docker images.
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -10,7 +10,7 @@ hero:
     alt: Chinmina Bridge logo
   actions:
     - text: Learn more
-      link: introduction
+      link: /introduction
       icon: information
     - text: Getting Started
       link: /guides/getting-started

--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -29,7 +29,7 @@ deployments from a handful to hundreds of repositories.
    store and refresh: it's entirely automatic.
 
 2. Tokens with wider permissions can be supplied using
-   [profiles](guides/customizing-permissions), with the same lifetime and
+   [profiles](/guides/customizing-permissions), with the same lifetime and
    protections as the default access tokens.
 
 3. Issuing [deploy keys per
@@ -43,10 +43,10 @@ deployments from a handful to hundreds of repositories.
    GitHub.
 
 5. With KMS, the highly sensitive private key cannot be extracted. When
-   configured [as described in our guide](guides/kms), the Chinmina service uses
+   configured [as described in our guide](/guides/kms), the Chinmina service uses
    KMS to sign the GitHub JWT, and never has access to the raw key material.
 
-6. [Audit-friendly logs are written](reference/auditing) for each token
+6. [Audit-friendly logs are written](/reference/auditing) for each token
    request, whether successful or unsuccessful. These can be readily connected
    to your SIEM system, adding transparency and traceability to the system.
 
@@ -55,8 +55,8 @@ deployments from a handful to hundreds of repositories.
 1. Pipelines are automatically given access to the repository they're configured
    for.
 
-2. Via [profiles](guides/customizing-permissions) with their flexible [matching
-   rules](reference/profiles/matching), additional sets of permissions can be
+2. Via [profiles](/guides/customizing-permissions) with their flexible [matching
+   rules](/reference/profiles/matching), additional sets of permissions can be
    declared centrally and accessed as required.
 
 3. Chinmina is a straightforward Go application in a minimal container with
@@ -75,7 +75,7 @@ deployments from a handful to hundreds of repositories.
 3. The private key for the GitHub application is extremely powerful, and needs
    to be carefully protected. It has the superset of permissions that it can
    delegate. Storing the key in AWS KMS and using careful resource and IAM
-   policies on access is therefore [strongly recommended](guides/kms).
+   policies on access is therefore [strongly recommended](/guides/kms).
 
 4. Adequate controls are required on Buildkite pipeline creation. At present,
    the bridge will allow access by the pipeline to the configured repository.
@@ -119,7 +119,7 @@ their own, useful for shared resources like private Buildkite plugins or
 Homebrew taps. Organization profiles use the `/organization/token/{profile}` and
 `/organization/git-credentials/{profile}` routes.
 
-Both profile types can optionally [restrict access](reference/profiles/matching)
+Both profile types can optionally [restrict access](/reference/profiles/matching)
 to specific pipelines via claim matching.
 
 ## Endpoints

--- a/src/content/docs/reference/api/health-check-and-status.md
+++ b/src/content/docs/reference/api/health-check-and-status.md
@@ -5,7 +5,7 @@ description: Health check endpoint for monitoring Chinmina Bridge service availa
 
 The `GET /healthcheck` endpoint provides a simple mechanism to verify that the Chinmina Bridge service is running and accepting HTTP requests.
 
-For documentation of token-issuing endpoints, see [POST /token](./post-token), [POST /git-credentials](./git-credentials), and [Profile-Scoped Endpoints](./profile-scoped-endpoints).
+For documentation of token-issuing endpoints, see [POST /token](/reference/api/pipeline-token), [POST /git-credentials](/reference/api/pipeline-git-credentials), [POST /organization/token/{profile}](/reference/api/organization-token), and [POST /organization/git-credentials/{profile}](/reference/api/organization-git-credentials).
 
 ## Purpose
 

--- a/src/content/docs/reference/api/pipeline-git-credentials.md
+++ b/src/content/docs/reference/api/pipeline-git-credentials.md
@@ -9,12 +9,12 @@ Buildkite OIDC tokens.
 
 The profile parameter selects the pipeline profile that will be used when
 creating the token using permissions defined by the specified [pipeline
-profile](../profiles/pipeline).
+profile](/reference/profiles/pipeline).
 
 The reserved profile name `default` is always available. The default profile can
 be requested via `POST /git-credentials/default` or `POST /git-credentials`.
 Permissions for the `default` profile [can be
-changed](../profiles/pipeline#default) but `match` rules cannot be added.
+changed](/reference/profiles/pipeline#defaults) but `match` rules cannot be added.
 
 ## Purpose
 
@@ -25,7 +25,7 @@ act as a Git credential helper, enabling transparent authentication for Git
 operations without requiring separate credential extraction and configuration
 steps.
 
-See the [Buildkite integration guide](../../guides/buildkite-integration) for
+See the [Buildkite integration guide](/guides/buildkite-integration) for
 details on how this endpoint is used in practice.
 
 :::note
@@ -95,7 +95,7 @@ parses this and uses the credentials for the requested operation.
 
 When the requested repository does not match the pipeline's repository, the
 endpoint returns a successful but empty response. See [Git credentials
-format](../../reference/git-credentials-format#empty-response) for details on
+format](/reference/git-credentials-format#empty-response) for details on
 empty response behavior.
 
 ### Error responses
@@ -111,4 +111,4 @@ Error responses are returned in plain text. Any response that Git does not
 recognize as valid for the format is regarded as an error and discarded. Note
 that the server will never return client content as part of an error message.
 
-[helper-protocol]: ../git-credentials-format
+[helper-protocol]: /reference/git-credentials-format

--- a/src/content/docs/reference/api/pipeline-token.md
+++ b/src/content/docs/reference/api/pipeline-token.md
@@ -9,12 +9,12 @@ Buildkite OIDC tokens.
 
 The profile parameter selects the pipeline profile that will be used when
 creating the token using permissions defined by the specified [pipeline
-profile](../profiles/pipeline).
+profile](/reference/profiles/pipeline).
 
 The reserved profile name `default` is always available. The default profile can
 be requested via `POST /token/default` or `POST /token`.
 Permissions for the `default` profile [can be
-changed](../profiles/pipeline#default) but `match` rules cannot be added.
+changed](/reference/profiles/pipeline#defaults) but `match` rules cannot be added.
 
 ## Purpose
 
@@ -23,7 +23,7 @@ when you need token metadata, are making direct API calls, or want more flexible
 response handling.
 
 For Git credential helper integration, use the [`POST
-/git-credentials`](git-credentials.md) endpoint instead, which returns tokens in
+/git-credentials`](/reference/api/pipeline-git-credentials) endpoint instead, which returns tokens in
 Git's credential helper format.
 
 :::note

--- a/src/content/docs/reference/profiles/index.md
+++ b/src/content/docs/reference/profiles/index.md
@@ -16,14 +16,14 @@ guarantees as the default token.
 
 Two profile types are available:
 
-- **[Pipeline profiles](pipeline)** - grant elevated permissions to the pipeline's own repository
-- **[Organization profiles](organization)** - provide access to other repositories across the organization
+- **[Pipeline profiles](/reference/profiles/pipeline)** - grant elevated permissions to the pipeline's own repository
+- **[Organization profiles](/reference/profiles/organization)** - provide access to other repositories across the organization
 
 ## Configuration
 
 Profiles are configured via a YAML file hosted in a GitHub repository. The
 location is specified using the
-[`GITHUB_ORG_PROFILE`](../configuration#github_org_profile) environment
+[`GITHUB_ORG_PROFILE`](/reference/configuration#github_org_profile) environment
 variable.
 
 The configuration file contains both profile types:
@@ -51,7 +51,7 @@ Configured permissions are additive: specifying `["contents:read"]` results in a
 
 ## Access control
 
-Both profile types support [claim-based matching](matching) to restrict which pipelines can use a profile. Match rules evaluate JWT claims from the Buildkite OIDC token, enabling fine-grained authorization based on pipeline identity, branch, cluster, or agent tags.
+Both profile types support [claim-based matching](/reference/profiles/matching) to restrict which pipelines can use a profile. Match rules evaluate JWT claims from the Buildkite OIDC token, enabling fine-grained authorization based on pipeline identity, branch, cluster, or agent tags.
 
 ## API access
 
@@ -64,7 +64,7 @@ The special name `default` accesses pipeline default permissions.
 
 ## See also
 
-- [Customizing token permissions guide](../../guides/customizing-permissions) - practical how-to for setting up and using profiles
-- [Profile matching reference](matching) - match rule syntax and available claims
+- [Customizing token permissions guide](/guides/customizing-permissions) - practical how-to for setting up and using profiles
+- [Profile matching reference](/reference/profiles/matching) - match rule syntax and available claims
 
 [github-fgpat]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens

--- a/src/content/docs/reference/profiles/matching.mdx
+++ b/src/content/docs/reference/profiles/matching.mdx
@@ -7,7 +7,7 @@ import { Aside } from "@astrojs/starlight/components"
 
 Profile matching restricts access to specific Buildkite pipelines using claim-based rules. Match rules evaluate JWT claims from the Buildkite OIDC token against configured patterns, providing fine-grained access control.
 
-Both [pipeline profiles](pipeline) and [organization profiles](organization) support the same matching syntax.
+Both [pipeline profiles](/reference/profiles/pipeline) and [organization profiles](/reference/profiles/organization) support the same matching syntax.
 
 ## Match rule syntax
 
@@ -173,7 +173,7 @@ match:
 Pipeline doesn't match profile conditions.
 
 The HTTP response returns a generic "Forbidden" message. Check [audit
-logs](../auditing) for `token.attemptedPatterns` to see which condition failed
+logs](/reference/auditing) for `token.attemptedPatterns` to see which condition failed
 and the `error` field for detailed information. Verify the pipeline's claim
 values match the configured patterns.
 

--- a/src/content/docs/reference/profiles/pipeline.md
+++ b/src/content/docs/reference/profiles/pipeline.md
@@ -31,7 +31,7 @@ Default permissions applied to all pipeline token requests when no profile is sp
 
 ###### `permissions`
 
-List of GitHub permissions. The `metadata:read` permission is [automatically included](../profiles#automatic-permissions) in all tokens. See the [GitHub documentation for tokens][github-token-permissions] for available permission values.
+List of GitHub permissions. The `metadata:read` permission is [automatically included](/reference/profiles#automatic-permissions) in all tokens. See the [GitHub documentation for tokens][github-token-permissions] for available permission values.
 
 ##### `profiles`
 
@@ -47,7 +47,7 @@ _(optional)_
 
 Claim matching rules that restrict which pipelines can use this profile. Omit this field entirely to make the profile available to all pipelines.
 
-See the [profile matching reference](matching) for complete details on:
+See the [profile matching reference](/reference/profiles/matching) for complete details on:
 
 - Match rule syntax (exact vs regex matching)
 - Available claims
@@ -56,7 +56,7 @@ See the [profile matching reference](matching) for complete details on:
 
 ###### `permissions`
 
-GitHub permissions granted by this profile. The `metadata:read` permission is [automatically included](../profiles#automatic-permissions) in all tokens.
+GitHub permissions granted by this profile. The `metadata:read` permission is [automatically included](/reference/profiles#automatic-permissions) in all tokens.
 
 ### Example
 

--- a/src/content/docs/reference/telemetry/index.md
+++ b/src/content/docs/reference/telemetry/index.md
@@ -17,7 +17,7 @@ Distributed traces track request execution through the system. Chinmina creates 
 
 Traces show parent-child relationships between operations, timing information, and error details.
 
-See [traces reference](traces) for complete span documentation.
+See [traces reference](/reference/telemetry/traces) for complete span documentation.
 
 ### Metrics
 
@@ -29,7 +29,7 @@ Metrics provide quantitative measurements of system behavior. Chinmina collects 
 
 Metrics include dimensional attributes for filtering and aggregation.
 
-See [metrics reference](metrics) for complete metric documentation.
+See [metrics reference](/reference/telemetry/metrics) for complete metric documentation.
 
 ## Exporters
 
@@ -60,6 +60,6 @@ Context propagation enables distributed tracing across service boundaries. Incom
 
 ## Configuration
 
-For configuration instructions, see the [observability guide](../../guides/observability).
+For configuration instructions, see the [observability guide](/guides/observability).
 
-For complete configuration reference, see the [configuration reference](../configuration).
+For complete configuration reference, see the [configuration reference](/reference/configuration).

--- a/src/content/docs/reference/telemetry/metrics.md
+++ b/src/content/docs/reference/telemetry/metrics.md
@@ -37,7 +37,7 @@ Size of the response body.
 
 When `OBSERVE_HTTP_TRANSPORT_ENABLED=true`, outgoing requests to Buildkite and GitHub APIs are wrapped with `otelhttp.NewTransport()`, producing client-side HTTP semantic convention metrics. These mirror the server metrics above with a `http.client.*` prefix.
 
-Connection-level trace attributes (DNS, TLS handshake timing) are added when `OBSERVE_CONNECTION_TRACE_ENABLED=true`. See [traces](./traces#connection-trace-attributes) for details.
+Connection-level trace attributes (DNS, TLS handshake timing) are added when `OBSERVE_CONNECTION_TRACE_ENABLED=true`. See [traces](/reference/telemetry/traces#connection-trace-attributes) for details.
 
 ## cache.operations
 
@@ -169,8 +169,8 @@ The `cache.type` attribute distinguishes between different cache instances. Curr
 
 For metric configuration details, see:
 
-- [Configuration reference](../configuration) for `OBSERVE_METRICS_*` variables
-- [Observability guide](../../guides/observability) for setup instructions
+- [Configuration reference](/reference/configuration) for `OBSERVE_METRICS_*` variables
+- [Observability guide](/guides/observability) for setup instructions
 
 [otelhttp]: https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
 [semconv-http]: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/

--- a/src/content/docs/reference/telemetry/traces.md
+++ b/src/content/docs/reference/telemetry/traces.md
@@ -203,5 +203,5 @@ Background profile refresh operations generate additional traces periodically ba
 
 For span configuration details, see:
 
-- [Configuration reference](../configuration) for `OBSERVE_*` variables
-- [Observability guide](../../guides/observability) for setup instructions
+- [Configuration reference](/reference/configuration) for `OBSERVE_*` variables
+- [Observability guide](/guides/observability) for setup instructions


### PR DESCRIPTION
## Purpose

Adds `starlight-links-validator` so a broken internal link fails `pnpm run build` instead of shipping to production silently. Running it surfaced real breakage across the site: several pages — mostly directory index pages, whose URL has no trailing slash — resolved their own sibling links one directory level too high in the browser (e.g. `reference/profiles/index.md` linking `matching` resolved to `/reference/matching` instead of `/reference/profiles/matching`), and a handful of hand-written paths pointed at renamed or nonexistent pages/anchors (a `#default` anchor where the heading is `defaults`, a `git-credentials.md` link to a page that was renamed to `pipeline-git-credentials`, and three links on the healthcheck page to endpoints that never existed under those names).

Every relative link in the docs corpus was converted to a root-absolute path as part of the fix, matching the validator's default policy — the plugin can only check absolute-path/anchor correctness; relative links are either banned outright or skipped entirely, so leaving any in place would have left this whole class of bug free to recur silently.

## Context

Found by a user manually catching one broken link (`reference/profiles/index.md`) after I'd (incorrectly) disabled the validator's relative-link check to silence what looked like noise. Re-enabling it and verifying every flagged link individually is what turned up the rest.

Stacked on #41 (`docs/repository-scope-validation`): the two organization-profile and configuration-reference pages that PR also touches are excluded here to avoid duplicate diffs.