### PR TITLE
build: adopt rumdl as a Markdown/MDX linting guard

### DIFF
--- a/.claude/skills/docs/references/content-types.md
+++ b/.claude/skills/docs/references/content-types.md
@@ -106,7 +106,7 @@ When introducing a new concept, follow this structure:
 
 ### Directory Structure
 
-```
+```text
 src/content/docs/
 ├── index.mdx                    # Landing page
 ├── introduction.md              # System overview and concepts (Explanation)

--- a/.claude/skills/update-plugin-versions/SKILL.md
+++ b/.claude/skills/update-plugin-versions/SKILL.md
@@ -26,6 +26,7 @@ First, fetch the latest versions from GitHub:
 ```
 
 **Output:** JSON with plugin names and versions
+
 ```json
 {
   "chinmina-token": "v1.3.1",
@@ -62,6 +63,7 @@ This shows bootstrap hooks, variable assignments, or other non-standard formats 
 ### 4. Manual Updates (LLM)
 
 For any references found in step 3:
+
 - Read the file to understand the format
 - Use Edit tool to update the version in context
 - The LLM adapts to whatever format is used (bash variables, etc.)
@@ -69,11 +71,13 @@ For any references found in step 3:
 ## Design Philosophy
 
 **Scripts encode deterministic actions:**
+
 - Fetching versions from GitHub
 - Replacing standard plugin#version format
 - Finding references with context
 
 **LLM handles contextual understanding:**
+
 - Understanding non-standard formats (bootstrap hooks, etc.)
 - Making targeted edits in appropriate context
 - Adapting to new patterns without script changes

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -18,10 +18,9 @@ respect-gitignore = true
 # Ratchet candidates: currently violated by a handful of files, not yet
 # fixed. Re-enable one rule at a time, fix its violations, and remove it
 # from this list in its own commit.
-# - MD033, MD036
+# - MD033
 disable = [
   "MD013",
   "MD001",
   "MD033",
-  "MD036",
 ]

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -18,12 +18,11 @@ respect-gitignore = true
 # Ratchet candidates: currently violated by a handful of files, not yet
 # fixed. Re-enable one rule at a time, fix its violations, and remove it
 # from this list in its own commit.
-# - MD012, MD030, MD033, MD034, MD036, MD039, MD053
+# - MD012, MD033, MD034, MD036, MD039, MD053
 disable = [
   "MD013",
   "MD001",
   "MD012",
-  "MD030",
   "MD033",
   "MD034",
   "MD036",

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -18,7 +18,7 @@ respect-gitignore = true
 # Ratchet candidates: currently violated by a handful of files, not yet
 # fixed. Re-enable one rule at a time, fix its violations, and remove it
 # from this list in its own commit.
-# - MD012, MD030, MD033, MD034, MD036, MD039, MD040, MD053
+# - MD012, MD030, MD033, MD034, MD036, MD039, MD053
 disable = [
   "MD013",
   "MD001",
@@ -28,6 +28,5 @@ disable = [
   "MD034",
   "MD036",
   "MD039",
-  "MD040",
   "MD053",
 ]

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -18,14 +18,12 @@ respect-gitignore = true
 # Ratchet candidates: currently violated by a handful of files, not yet
 # fixed. Re-enable one rule at a time, fix its violations, and remove it
 # from this list in its own commit.
-# - MD012, MD033, MD034, MD036, MD039, MD053
+# - MD033, MD034, MD036, MD053
 disable = [
   "MD013",
   "MD001",
-  "MD012",
   "MD033",
   "MD034",
   "MD036",
-  "MD039",
   "MD053",
 ]

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -18,12 +18,11 @@ respect-gitignore = true
 # Ratchet candidates: currently violated by a handful of files, not yet
 # fixed. Re-enable one rule at a time, fix its violations, and remove it
 # from this list in its own commit.
-# - MD033, MD034, MD036, MD053
+# - MD033, MD036, MD053
 disable = [
   "MD013",
   "MD001",
   "MD033",
-  "MD034",
   "MD036",
   "MD053",
 ]

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -15,12 +15,18 @@ respect-gitignore = true
 #   Parameter Documentation"). Enforcing sequential levels would fight a
 #   deliberate pattern used across every reference page.
 #
-# Ratchet candidates: currently violated by a handful of files, not yet
-# fixed. Re-enable one rule at a time, fix its violations, and remove it
-# from this list in its own commit.
-# - MD033
+# All previously identified ratchet candidates (MD012, MD030, MD031,
+# MD032, MD033, MD034, MD036, MD039, MD040, MD053) have been re-enabled
+# and fixed, except for one MD033 exception below.
 disable = [
   "MD013",
   "MD001",
-  "MD033",
 ]
+
+# getting-started.mdx defines a JSX component (`ConfigRef`) inline; its
+# <code>/<em> are JSX elements, not Markdown inline HTML. rumdl's inline
+# rumdl-disable comment can't be used here: MDX doesn't support raw HTML
+# comments at all (`<!-- -->` fails to parse), only MDX's `{/* */}` form,
+# which rumdl's inline configuration doesn't recognise.
+[per-file-ignores]
+"src/content/docs/guides/getting-started.mdx" = ["MD033"]

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -18,14 +18,12 @@ respect-gitignore = true
 # Ratchet candidates: currently violated by a handful of files, not yet
 # fixed. Re-enable one rule at a time, fix its violations, and remove it
 # from this list in its own commit.
-# - MD012, MD030, MD031, MD032, MD033, MD034, MD036, MD039, MD040, MD053
+# - MD012, MD030, MD033, MD034, MD036, MD039, MD040, MD053
 disable = [
   "MD013",
   "MD001",
   "MD012",
   "MD030",
-  "MD031",
-  "MD032",
   "MD033",
   "MD034",
   "MD036",

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,35 @@
+[global]
+respect-gitignore = true
+
+# Disabled rules, split into two groups. Re-enabling any of these is a
+# separate, deliberate commit — see docs/prd-cloudflare-pages-migration.md
+# sibling notes or the PR description for the current ratchet plan.
+#
+# Permanent: conflicts with a documented convention in this repository.
+# - MD013 (line-length): prose is written one sentence/paragraph per line,
+#   not hard-wrapped at a column width. Wrapping would produce noisy diffs
+#   for a formatting rule this repo has never followed.
+# - MD001 (heading-increment): reference pages intentionally jump from H3
+#   to H6 for parameter documentation (see
+#   .claude/skills/docs/references/mdx-conventions.md, "Configuration
+#   Parameter Documentation"). Enforcing sequential levels would fight a
+#   deliberate pattern used across every reference page.
+#
+# Ratchet candidates: currently violated by a handful of files, not yet
+# fixed. Re-enable one rule at a time, fix its violations, and remove it
+# from this list in its own commit.
+# - MD012, MD030, MD031, MD032, MD033, MD034, MD036, MD039, MD040, MD053
+disable = [
+  "MD013",
+  "MD001",
+  "MD012",
+  "MD030",
+  "MD031",
+  "MD032",
+  "MD033",
+  "MD034",
+  "MD036",
+  "MD039",
+  "MD040",
+  "MD053",
+]

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -18,11 +18,10 @@ respect-gitignore = true
 # Ratchet candidates: currently violated by a handful of files, not yet
 # fixed. Re-enable one rule at a time, fix its violations, and remove it
 # from this list in its own commit.
-# - MD033, MD036, MD053
+# - MD033, MD036
 disable = [
   "MD013",
   "MD001",
   "MD033",
   "MD036",
-  "MD053",
 ]

--- a/biome.json
+++ b/biome.json
@@ -26,6 +26,7 @@
       "!.astro",
       "!.claude",
       "!.github",
+      "!.rumdl_cache",
       "!.vscode",
       "!dist",
       "!public"

--- a/docs/prd-cloudflare-pages-migration.md
+++ b/docs/prd-cloudflare-pages-migration.md
@@ -61,6 +61,7 @@ Deploy the site to Cloudflare Pages (project: `chinmina`) via the existing GitHu
 **GitHub Pages remains live**: GitHub Pages is not disabled as part of this work. It continues to receive deployments from `main` and serves the site at `chinmina.github.io` with canonical links pointing to `docs.chinmina.dev`. Decommissioning GitHub Pages is deferred to a future redirect-strategy workstream.
 
 **GitHub Actions secrets needed**:
+
 - `CLOUDFLARE_API_TOKEN` — scoped to Cloudflare Pages edit permissions
 - `CLOUDFLARE_ACCOUNT_ID` — the Cloudflare account hosting the `chinmina` project
 

--- a/package.json
+++ b/package.json
@@ -8,12 +8,15 @@
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "agent": "biome check --write --unsafe && vitest run && pnpm run build",
+    "agent": "biome check --write --unsafe && rumdl fmt && vitest run && pnpm run build",
     "test": "vitest run",
     "lint": "biome lint",
     "lint:fix": "biome lint --write --unsafe",
+    "lint:md": "rumdl check",
+    "lint:md:fix": "rumdl check --fix",
     "fmt": "biome format --write",
-    "fmt:check": "biome format"
+    "fmt:check": "biome format",
+    "fmt:md": "rumdl fmt"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.10",
@@ -32,6 +35,7 @@
     "remark-mdx": "^3.1.0",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
+    "rumdl": "^0.2.55",
     "unified": "^11.0.5",
     "vitest": "^4.1.10",
     "wrangler": "^4.123.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "agent": "biome check --write --unsafe && rumdl fmt && vitest run && pnpm run build",
+    "agent": "biome check --write --unsafe && rumdl check --fix && vitest run && pnpm run build",
     "test": "vitest run",
     "lint": "biome lint",
     "lint:fix": "biome lint --write --unsafe",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       remark-stringify:
         specifier: ^11.0.0
         version: 11.0.0
+      rumdl:
+        specifier: ^0.2.55
+        version: 0.2.55
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -1305,6 +1308,48 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@rumdl/cli-darwin-arm64@0.2.55':
+    resolution: {integrity: sha512-hLXvQ+rL1TTz9GyOtVqUlJvzEQ7Ry19+6xnYVCm/G3wDeZGvHEvhbkxjy3AWoTcWg3njnfiQZ+mLavu/9xz06A==}
+    engines: {node: '>=18.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rumdl/cli-darwin-x64@0.2.55':
+    resolution: {integrity: sha512-DvHBCeWQ1GQwOWSbS8+3FL6sh8OQKUjVDl4lAcJnYaSIeSHlu8Y/zJPJVANnmpzVpi8daIOgqM6LvYVka5V86Q==}
+    engines: {node: '>=18.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rumdl/cli-linux-arm64-musl@0.2.55':
+    resolution: {integrity: sha512-6pnrMavpmhz6JJL7oiNP26qx5Tp5QQXjTjfZ4horyO4DoAineL7y63Pa2/tr8OV9gfhR02mx7Rs3Est1movaQg==}
+    engines: {node: '>=18.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rumdl/cli-linux-arm64@0.2.55':
+    resolution: {integrity: sha512-LZvSjhjXkZ9zPXa1IV4v3cMSgf2lC4DL9s2Yp8VRQhR0zb1IvmKWKF5h1FxES8ENHOkzjGFfivChCndM1Np6qg==}
+    engines: {node: '>=18.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rumdl/cli-linux-x64-musl@0.2.55':
+    resolution: {integrity: sha512-7dC9ni1rMCrQbrJKTIISuXtYtmwISnoBUoXNOGh4uYX+R0GQQA6u75sF4xuNQ8xcK/Xie4BPH0uJhXjbe4TWkQ==}
+    engines: {node: '>=18.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@rumdl/cli-linux-x64@0.2.55':
+    resolution: {integrity: sha512-u7UqjS+wfL27zejSjnTItOVHUnHGOsgJ45oS6wvE6x86buyCcpmoYPqe/fkDf9ZcEP5JpnH5gU8NZWTUAKqf0Q==}
+    engines: {node: '>=18.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@rumdl/cli-win32-x64@0.2.55':
+    resolution: {integrity: sha512-Ah7Jqod0x8lhnpAPWFAipnFfQL2PguqUZvb4x3JaKckmQYWY6dS0tAhpuOzof7IlgsFB+Hgmpc315R5Y68r9vA==}
+    engines: {node: '>=18.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@shikijs/core@4.0.2':
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
     engines: {node: '>=20'}
@@ -2535,6 +2580,11 @@ packages:
   rolldown@1.2.4:
     resolution: {integrity: sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rumdl@0.2.55:
+    resolution: {integrity: sha512-sMh65AFPWcqTgrRDI8JRQbbzbin475juGMOAiAbEot7jnmXRG6At43saT9gmdMM4p4B/lPuV4Ci05m/fJIFqJQ==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
   satteri@0.9.5:
@@ -4113,6 +4163,27 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
+
+  '@rumdl/cli-darwin-arm64@0.2.55':
+    optional: true
+
+  '@rumdl/cli-darwin-x64@0.2.55':
+    optional: true
+
+  '@rumdl/cli-linux-arm64-musl@0.2.55':
+    optional: true
+
+  '@rumdl/cli-linux-arm64@0.2.55':
+    optional: true
+
+  '@rumdl/cli-linux-x64-musl@0.2.55':
+    optional: true
+
+  '@rumdl/cli-linux-x64@0.2.55':
+    optional: true
+
+  '@rumdl/cli-win32-x64@0.2.55':
+    optional: true
 
   '@shikijs/core@4.0.2':
     dependencies:
@@ -5937,6 +6008,16 @@ snapshots:
       '@rolldown/binding-openharmony-arm64': 1.2.4
       '@rolldown/binding-win32-arm64-msvc': 1.2.4
       '@rolldown/binding-win32-x64-msvc': 1.2.4
+
+  rumdl@0.2.55:
+    optionalDependencies:
+      '@rumdl/cli-darwin-arm64': 0.2.55
+      '@rumdl/cli-darwin-x64': 0.2.55
+      '@rumdl/cli-linux-arm64': 0.2.55
+      '@rumdl/cli-linux-arm64-musl': 0.2.55
+      '@rumdl/cli-linux-x64': 0.2.55
+      '@rumdl/cli-linux-x64-musl': 0.2.55
+      '@rumdl/cli-win32-x64': 0.2.55
 
   satteri@0.9.5:
     dependencies:

--- a/src/content/docs/guides/buildkite-integration.mdx
+++ b/src/content/docs/guides/buildkite-integration.mdx
@@ -374,8 +374,5 @@ pipeline settings.
 
 </Steps>
 
-[chinmina-bridge]: ../introduction/
 [chinmina-token]: https://github.com/chinmina/chinmina-token-buildkite-plugin
 [credentials-plugin]: https://github.com/chinmina/chinmina-git-credentials-buildkite-plugin
-[pipeline-configuration]: https://buildkite.com/docs/pipelines/defining-steps
-[library-plugin]: https://buildkite.com/docs/plugins/writing-plugins/library-plugins

--- a/src/content/docs/guides/buildkite-integration.mdx
+++ b/src/content/docs/guides/buildkite-integration.mdx
@@ -305,8 +305,8 @@ pipeline settings.
 
 <Steps>
 
-1.  Alter the agent `bootstrap` hook to clone both plugin sources to the agent so
-    they can be activated by any step.
+1. Alter the agent `bootstrap` hook to clone both plugin sources to the agent so
+   they can be activated by any step.
 
     ```bash
     # Chinmina Token plugin
@@ -338,9 +338,9 @@ pipeline settings.
         "${plugin_repo}" "${plugin_dir}"
     ```
 
-2.  Set default configuration values and call the plugins' `environment` hooks
-    directly from the agent's `environment` hook. These defaults will be used
-    by all pipelines unless explicitly overridden.
+2. Set default configuration values and call the plugins' `environment` hooks
+   directly from the agent's `environment` hook. These defaults will be used
+   by all pipelines unless explicitly overridden.
 
     ```bash title="Execute plugin environment hooks directly"
     # Set organization-wide defaults (both plugins use these)
@@ -354,8 +354,8 @@ pipeline settings.
     source /buildkite/plugins/chinmina-git-credentials-buildkite-plugin/hooks/environment
     ```
 
-    With this configuration, pipelines no longer need to specify `chinmina-url`
-    and `audience` parameters:
+   With this configuration, pipelines no longer need to specify `chinmina-url`
+   and `audience` parameters:
 
     ```yml
     plugins:
@@ -364,13 +364,13 @@ pipeline settings.
             - GITHUB_TOKEN=pipeline:default
     ```
 
-    :::note
+   :::note
 
-    The bootstrap hook is only run when the agent starts. Cloning the plugins in
-    the bootstrap hook is more efficient than doing so in the environment hook,
-    and also faster.
+   The bootstrap hook is only run when the agent starts. Cloning the plugins in
+   the bootstrap hook is more efficient than doing so in the environment hook,
+   and also faster.
 
-    :::
+   :::
 
 </Steps>
 

--- a/src/content/docs/guides/customizing-permissions.mdx
+++ b/src/content/docs/guides/customizing-permissions.mdx
@@ -62,7 +62,7 @@ Organization profiles provide controlled access to a static list of repositories
 
    Set the `GITHUB_ORG_PROFILE` environment variable to the location of your configuration file:
 
-   ```
+   ```bash
    GITHUB_ORG_PROFILE=your-org:config-repo:path/to/profiles.yaml
    ```
 
@@ -74,7 +74,7 @@ Organization profiles provide controlled access to a static list of repositories
 
    Check Chinmina logs at startup. If the profile file loads successfully, you'll see profile statistics:
 
-   ```
+   ```text
    [info] Profiles loaded: 2 pipeline, 1 organization
    ```
 

--- a/src/content/docs/guides/getting-started.mdx
+++ b/src/content/docs/guides/getting-started.mdx
@@ -76,8 +76,7 @@ Create an API key with access to the REST API **only** with access to the
 <Aside type="tip">
 
 For a production installation on AWS it is strongly recommended that you upload
-your private key to KMS, as documented in [Protecting the GitHub private key
-](/guides/kms)
+your private key to KMS, as documented in [Protecting the GitHub private key](/guides/kms)
 
 </Aside>
 
@@ -110,7 +109,6 @@ export function ConfigRef({ name, default: defaultValue }) {
     </>
   );
 }
-
 
 A minimal configuration of the service requires at least the configuration
 below. See the [Configuration](/reference/configuration) reference for details of all

--- a/src/content/docs/guides/getting-started.mdx
+++ b/src/content/docs/guides/getting-started.mdx
@@ -92,6 +92,8 @@ latency, not the correctness.
 
 #### Essential configuration
 
+{/* ConfigRef is a JSX component: the <code>/<em> below are JSX elements,
+    not Markdown inline HTML. */}
 export function ConfigRef({ name, default: defaultValue }) {
   // ConfigRef renders a link to the Chinmina configuration reference
 

--- a/src/content/docs/guides/verifying-releases.md
+++ b/src/content/docs/guides/verifying-releases.md
@@ -64,7 +64,7 @@ cosign verify "chinmina/chinmina-bridge:$TAG" \
 
 The path `.[].optional.Bundle.Payload.logIndex` is the index entry in the public
 transparency log, recording the details of the signing event. The details of the
-event can be found at: https://search.sigstore.dev/.
+event can be found at: <https://search.sigstore.dev/>.
 
 For a concrete example, check out the [log entry for
 v0.7.0](https://search.sigstore.dev/?logIndex=137373725).

--- a/src/content/docs/reference/profiles/organization.md
+++ b/src/content/docs/reference/profiles/organization.md
@@ -55,9 +55,9 @@ The name of the profile. This should be a unique identifier for the profile.
 
 ###### `match`
 
-_(optional)_
-
-Claim matching rules that restrict which pipelines can use this profile. Omit this field entirely to make the profile available to all pipelines.
+Optional claim matching rules that restrict which pipelines can use this
+profile. Omit this field entirely to make the profile available to all
+pipelines.
 
 See the [profile matching reference](/reference/profiles/matching) for complete details on:
 

--- a/src/content/docs/reference/profiles/pipeline.md
+++ b/src/content/docs/reference/profiles/pipeline.md
@@ -43,9 +43,9 @@ Profile identifier used in API requests. The name `default` is reserved and cann
 
 ###### `match`
 
-_(optional)_
-
-Claim matching rules that restrict which pipelines can use this profile. Omit this field entirely to make the profile available to all pipelines.
+Optional claim matching rules that restrict which pipelines can use this
+profile. Omit this field entirely to make the profile available to all
+pipelines.
 
 See the [profile matching reference](/reference/profiles/matching) for complete details on:
 

--- a/starlight.md
+++ b/starlight.md
@@ -2,7 +2,7 @@
 
 [![Built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build)
 
-```
+```bash
 npm create astro@latest -- --template starlight
 ```
 
@@ -17,7 +17,7 @@ npm create astro@latest -- --template starlight
 
 Inside of your Astro + Starlight project, you'll see the following folders and files:
 
-```
+```text
 .
 ├── public/
 ├── src/


### PR DESCRIPTION
## Purpose

Give documentation contributors an automated guard for Markdown/MDX style, closing a gap left by Biome (JS/TS/JSON/CSS only, no Markdown support). Without a linter, formatting drift - inconsistent list markers, missing blank lines, untagged code fences, dead link references - only gets caught by manual review, if at all, and tends to accumulate as more contributors touch the docs.

Adopted rumdl with a deliberately staged rollout rather than turning on every rule at once: rule-by-rule, each re-enabled only after its violations are fixed and verified against a full site build, so the guard tightens without a disruptive one-off rewrite or a wall of unrelated diff noise landing in a single commit. Two rules stay off permanently because they conflict with conventions this repo already relies on (unwrapped prose, and intentional heading-level jumps for parameter documentation), and one file keeps a narrow, documented exception where linting inline HTML would flag legitimate JSX rather than a real Markdown mistake.

The result: `pnpm run agent` (and any future CI wiring) now catches the same classes of Markdown inconsistency that Biome already catches for code, before they reach review.

## Context

- Recreates #44, which was accidentally merged into `docs/link-validation` rather than `main`. That branch has since landed on `main` via #41 and #42, so the nine rumdl commits are replayed here on top of `main` unchanged. Where `main`'s reviewed version of a file differs from the pre-merge branch (`reference/configuration.md`, revised during #41's review), `main`'s version wins.
- `.rumdl.toml` documents the rationale for every disabled rule inline, so the next contributor re-enabling a rule (or adding an exception) has the reasoning on hand rather than needing to reconstruct it.

Two commits here are not in #44, both fixing defects in the original rollout:

- **`.rumdl_cache/` excluded from biome.** rumdl writes a cache directory at the repo root, which biome then walks. `files.includes` already excludes the other generated directories, so the cache is added alongside them - otherwise `pnpm run fmt:check` fails for anyone who has run rumdl, and `pnpm run agent` quietly rewrites the cache via its `--write --unsafe` biome step.
- **`pnpm run agent` actually fails on Markdown violations.** The original wiring used `rumdl fmt`, which is a formatter: it applies what it can and always exits 0, so the chain continued to the build with violations still in the tree - the guard this PR exists to add did not hold. Switched to `rumdl check --fix`, which applies the same fixes and then exits 1 on whatever remains. Verified against the pinned 0.2.55 binary: a file with an unfixable MD033 alongside a fixable MD040 gives `fmt` exit 0 and `check --fix` exit 1. `fmt:md` still calls `rumdl fmt`, which is the right behaviour for editor and on-demand use.

## Verification

`biome check`, `rumdl check`, `astro check`, and `vitest run` all pass. The corrected `agent` guard was tested in both directions: exit 1 with a deliberate unfixable violation present, exit 0 on the clean tree.

The `astro build` half of `pnpm run agent` could not be completed here: `astro-d2` requires the `d2` binary, which is absent from this environment. That dependency is unchanged from `main` and unrelated to these changes.