### PR TITLE
ci: harden GitHub Actions security posture

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      deployments: write
       pull-requests: write
     environment:
       name: cloudflare
@@ -81,8 +82,14 @@ jobs:
             | jq -r 'select(.type == "pages-deploy-detailed") | .url // empty' \
             | head -1)
           echo "value=${url}" >> "$GITHUB_OUTPUT"
-          echo "### Cloudflare Pages" >> "$GITHUB_STEP_SUMMARY"
-          echo "**URL:** ${url}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create deployment record
+        if: always() && steps.deploy.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WRANGLER_OUTPUT_FILE_DIRECTORY: .wrangler-output
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: .github/scripts/cloudflare-deploy.sh deployment
 
       - name: Post PR comment
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,7 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      deployments: write
       pull-requests: write
     environment:
       name: cloudflare
@@ -82,14 +81,8 @@ jobs:
             | jq -r 'select(.type == "pages-deploy-detailed") | .url // empty' \
             | head -1)
           echo "value=${url}" >> "$GITHUB_OUTPUT"
-
-      - name: Create deployment record
-        if: always() && steps.deploy.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WRANGLER_OUTPUT_FILE_DIRECTORY: .wrangler-output
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: .github/scripts/cloudflare-deploy.sh deployment
+          echo "### Cloudflare Pages" >> "$GITHUB_STEP_SUMMARY"
+          echo "**URL:** ${url}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Post PR comment
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,18 +8,17 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  deployments: write
-  pull-requests: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - name: Install tools with mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
       - name: Enable corepack
         run: corepack enable
       - name: Install dependencies
@@ -27,7 +26,7 @@ jobs:
       - name: Build site
         run: pnpm run build
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/
@@ -36,15 +35,20 @@ jobs:
     needs: build
     if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     environment:
       name: cloudflare
       url: ${{ steps.cf-url.outputs.value }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Install tools with mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
         with:
           install_args: node
 
@@ -55,7 +59,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download dist artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,14 @@
+# zizmor configuration
+#
+# https://docs.zizmor.sh/configuration/
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # The org's shared reusable workflows are trusted via the
+        # `verified-actions` branch, which is protected and reviewed.
+        # Pin to that branch rather than a hash so updates land
+        # automatically when the branch is fast-forwarded.
+        "chinmina/.github/*": ref-pin
+        "*": hash-pin


### PR DESCRIPTION
## Purpose

Close the gaps zizmor flags in the deploy workflow so a compromised dependency or malicious PR has less to work with: a hijacked action tag can't swap out its code underneath us, a leaked `GITHUB_TOKEN` doesn't persist past the job that needed it, and each job only holds the permissions it actually uses.

## Context

- Third-party actions (`actions/checkout`, `jdx/mise-action`, `actions/upload-artifact`, `actions/download-artifact`) were referenced by mutable version tags, which can be repointed to different code without notice. They're now pinned to the commit SHA behind each tag.
- The workflow carried `id-token: write` left over from the GitHub Pages/OIDC deployment removed in an earlier change, and `deployments: write` that nothing in the current script path uses — both dropped. `pull-requests: write` is only needed for the Cloudflare preview comment step, so it's scoped to the `deploy-cloudflare` job instead of granted workflow-wide.
- Checkout steps now set `persist-credentials: false` so the job's token isn't left sitting in git config for the rest of the run.
- Added `.github/zizmor.yml` to keep the org's `chinmina/.github` reusable workflows pinned to their protected `verified-actions` branch rather than forcing a SHA pin there — branch pinning to `.github` is intentional and still enforced, it's just declared explicitly now so zizmor doesn't flag it.

A clean `zizmor` run (offline mode — the dev sandbox can't reach the GitHub API for the online `ref-confusion` check) now reports no findings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDmg8WaGpEjpuv6aErkkJj)_