### PR TITLE
docs: add Context7 site claim file

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/llmstxt/chinmina_dev_llms_txt",
+  "public_key": "pk_upHqYlKC8fA5TIC6u9AsI"
+}


### PR DESCRIPTION
## Purpose

Adding Context7 claim file to ownership of the site and enable Context7 to associate the public feed with this repository.

## Context

- Context7 site claim documentation requires a  at the repository root containing the site URL and public key.
- Site URL: https://context7.com/llmstxt/chinmina_dev_llms_txt
